### PR TITLE
Use `setup_requires` for installation dependencies.

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -110,7 +110,7 @@ setup(
     url='https://github.com/yurymalkov/hnsw',
     long_description="""hnsw""",
     ext_modules=ext_modules,
-    install_requires=['pybind11>=2.0', 'numpy'],
+    setup_requires=['pybind11>=2.0', 'numpy'],
     cmdclass={'build_ext': BuildExt},
     test_suite="tests",
     zip_safe=False,


### PR DESCRIPTION
Installing the python module via pip can fail in localised environments. Pip is unable to find dependencies, and so we should use `setup_requires` instead of `install_requires` to ensure the dependencies are available at setup. (These dependencies are not installed at the system level.)

See: https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords