### PR TITLE
Add preprocessor directives for non-portable code.

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -184,15 +184,19 @@ namespace hnswlib {
                     data = (int *) (linkLists_[curNodeNum] + (layer - 1) * size_links_per_element_);
                 int size = *data;
                 tableint *datal = (tableint *) (data + 1);
+        #ifdef USE_SSE
                 _mm_prefetch((char *) (visited_array + *(data + 1)), _MM_HINT_T0);
                 _mm_prefetch((char *) (visited_array + *(data + 1) + 64), _MM_HINT_T0);
                 _mm_prefetch(getDataByInternalId(*datal), _MM_HINT_T0);
                 _mm_prefetch(getDataByInternalId(*(datal + 1)), _MM_HINT_T0);
+        #endif
 
                 for (int j = 0; j < size; j++) {
                     tableint candidate_id = *(datal + j);
+        #ifdef USE_SSE
                     _mm_prefetch((char *) (visited_array + *(datal + j + 1)), _MM_HINT_T0);
                     _mm_prefetch(getDataByInternalId(*(datal + j + 1)), _MM_HINT_T0);
+        #endif
                     if (visited_array[candidate_id] == visited_array_tag) continue;
                     visited_array[candidate_id] = visited_array_tag;
                     char *currObj1 = (getDataByInternalId(candidate_id));
@@ -200,7 +204,9 @@ namespace hnswlib {
                     dist_t dist1 = fstdistfunc_(data_point, currObj1, dist_func_param_);
                     if (top_candidates.top().first > dist1 || top_candidates.size() < ef_construction_) {
                         candidateSet.emplace(-dist1, candidate_id);
+        #ifdef USE_SSE
                         _mm_prefetch(getDataByInternalId(candidateSet.top().second), _MM_HINT_T0);
+        #endif
                         top_candidates.emplace(dist1, candidate_id);
                         if (top_candidates.size() > ef_construction_) {
                             top_candidates.pop();
@@ -241,16 +247,20 @@ namespace hnswlib {
                 tableint current_node_id = current_node_pair.second;
                 int *data = (int *) (data_level0_memory_ + current_node_id * size_data_per_element_ + offsetLevel0_);
                 int size = *data;
+        #ifdef USE_SSE
                 _mm_prefetch((char *) (visited_array + *(data + 1)), _MM_HINT_T0);
                 _mm_prefetch((char *) (visited_array + *(data + 1) + 64), _MM_HINT_T0);
                 _mm_prefetch(data_level0_memory_ + (*(data + 1)) * size_data_per_element_ + offsetData_, _MM_HINT_T0);
                 _mm_prefetch((char *) (data + 2), _MM_HINT_T0);
+        #endif
 
                 for (int j = 1; j <= size; j++) {
                     int candidate_id = *(data + j);
+        #ifdef USE_SSE
                     _mm_prefetch((char *) (visited_array + *(data + j + 1)), _MM_HINT_T0);
                     _mm_prefetch(data_level0_memory_ + (*(data + j + 1)) * size_data_per_element_ + offsetData_,
                                  _MM_HINT_T0);////////////
+        #endif
                     if (!(visited_array[candidate_id] == visited_array_tag)) {
 
                         visited_array[candidate_id] = visited_array_tag;
@@ -260,9 +270,11 @@ namespace hnswlib {
 
                         if (top_candidates.top().first > dist || top_candidates.size() < ef) {
                             candidate_set.emplace(-dist, candidate_id);
+        #ifdef USE_SSE
                             _mm_prefetch(data_level0_memory_ + candidate_set.top().second * size_data_per_element_ +
                                          offsetLevel0_,///////////
                                          _MM_HINT_T0);////////////////////////
+        #endif
 
                             top_candidates.emplace(dist, candidate_id);
 
@@ -631,12 +643,12 @@ namespace hnswlib {
             data_ptr += 1;
           }
           return data;
-        };
+        }
 
         void addPoint(void *data_point, labeltype label)
         {
             addPoint(data_point, label,-1);
-        };
+        }
 
         tableint addPoint(void *data_point, labeltype label, int level) {
 

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -1,22 +1,31 @@
 #pragma once
+#ifndef NO_MANUAL_VECTORIZATION
+#ifdef __SSE__
+#define USE_SSE
+#ifdef __AVX__
+#define USE_AVX
+#endif
+#endif
+#endif
+
+#if defined(USE_AVX) || defined(USE_SSE)
 #ifdef _MSC_VER
 #include <intrin.h>
 #include <stdexcept>
-
-#define  __builtin_popcount(t) __popcnt(t)
-
+#else
+#include <x86intrin.h>
 #endif
-
-
-#include <queue>
-
-#include <string.h>
 
 #if defined(__GNUC__)
 #define PORTABLE_ALIGN32 __attribute__((aligned(32)))
 #else
 #define PORTABLE_ALIGN32 __declspec(align(32))
 #endif
+#endif
+
+#include <queue>
+
+#include <string.h>
 
 namespace hnswlib {
     typedef size_t labeltype;
@@ -45,6 +54,7 @@ namespace hnswlib {
 
         virtual void *get_dist_func_param() = 0;
 
+        virtual ~SpaceInterface() {}
     };
 
     template<typename dist_t>


### PR DESCRIPTION
In order to submit the [R bindings for HNSW](https://github.com/jlmelville/rcpphnsw) to CRAN, it is a requirement that C++ code build without needing non-portable flags like `-march=native`. @LTLA and I have made those changes and we were wondering if this might also be useful for those hoping to use HNSW on architectures without AVX, SSE and the like. Hence this PR.

Changes in roughly decreasing order of importance:
* Added a preprocessor token`NO_MANUAL_VECTORIZATION`. If defined (e.g. by using `-DNO_MANUAL_VECTORIZATION` in the compiler flags), then you don't need to specify `-march=native`  and AVX and SSE will not be used. If you don't define `NO_MANUAL_VECTORIZATION` then the code will build as before, i.e. anyone who doesn't care about this should be unaffected.
* There are some other tokens defined such as `USE_SSE` and `USE_AVX`, but these are intended for internal use only.
* Added some virtual destructors.
* Removed an unused variable.