### PR TITLE
support deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,33 @@ Note that inner product is not a metric. An element can be closer to some other 
 
 For other spaces use the nmslib library https://github.com/nmslib/nmslib. 
 
+#### short API description
+* ```hnswlib.Index(space, dim)``` creates a non-initalized index an HNSW in space ```space``` with integer dimension ```dim```.
 
+Index methods:
+* ```init_index(max_elements, ef_construction = 200, M = 16, random_seed = 100)``` initalizes the index from with no elements. 
+    * ```max_elements``` defines the maximum number of elements that can be stored in the structure(can be increased/shrunk via saving/loading).
+    * ```ef_construction``` defines a construcion time/accuracy tradeoff (see [ALGO_PARAMS.md](ALGO_PARAMS.md)).
+    * ```M``` defines tha maximum number of outgoing connections in the graph ([ALGO_PARAMS.md](ALGO_PARAMS.md)).
+* ```add_items(data, data_labels, num_threads = -1)``` - inserts the ```data```(numpy array of vectors, shape:```N*dim```) into the structure. 
+    * ```labels``` is an optional N-size numpy array of integer labels for all elements in ```data```.
+    * ```num_threads``` sets the number of cpu threads to use (-1 means use default).
+* ```set_ef(ef)``` - sets the query time accuracy/speed tradeoff, defined by the ```ef``` parameter (
+[ALGO_PARAMS.md](ALGO_PARAMS.md)).
+* ```knn_query(data, k = 1, num_threads = -1)``` make a batch query for ```k``` closests elements for each element of the 
+    * ```data``` (shape:```N*dim```). Returns a numpy array of (shape:```N*k```).
+    * ```num_threads``` sets the number of cpu threads to use (-1 means use default).
+* ```load_index(path_to_index, max_elements = 0)``` loads the index from persistence to the unintialized index.
+    * ```max_elements```(optional) resets the maximum number of elements in the structure.  
+* ```save_index(path_to_index)``` saves the index from persistence.
+* ```set_num_threads(num_threads)``` set the defualt number of cpu threads used during data insertion/querying.  
+* ```get_items(ids)``` - returns a numpy array (shape:```N*dim```) of vectors that have integer identifiers specified in ```ids``` numpy vector (shape:```N```).  
+* ```get_ids_list()```  - returns a list of all element ids.
+
+   
+        
+        
+  
 #### Python bindings examples
 ```python
 import hnswlib

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -633,7 +633,13 @@ namespace hnswlib {
         template<typename data_t>
         std::vector<data_t> getDataByLabel(labeltype label)
         {
-          tableint label_c = label_lookup_[label];
+          tableint label_c;
+          auto search = label_lookup_.find(label);
+          if (search == label_lookup_.end()) {
+              throw std::runtime_error("Label not found");
+          }
+          label_c = search->second;
+
           char* data_ptrv = getDataByInternalId(label_c);
           size_t dim = *((size_t *) dist_func_param_);
           std::vector<data_t> data;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -127,6 +127,7 @@ namespace hnswlib {
         size_t label_offset_;
         DISTFUNC<dist_t> fstdistfunc_;
         void *dist_func_param_;
+        std::unordered_map<labeltype, tableint> label_lookup_;
 
         std::default_random_engine level_generator_;
 
@@ -616,6 +617,20 @@ namespace hnswlib {
             return;
         }
 
+        std::vector<dist_t> getDataByLabel(labeltype label)
+        {
+          tableint label_c = label_lookup_[label];
+          char* data_ptrv = getDataByInternalId(label_c);
+          size_t dim = *((size_t *) dist_func_param_);
+          std::vector<dist_t> data;
+          float* data_ptr = (float*) data_ptrv;
+          for (int i = 0; i < dim; i++) {
+            data.push_back(*data_ptr);
+            data_ptr += 1;
+          }
+          return data;
+        };
+
         void addPoint(void *data_point, labeltype label)
         {
             addPoint(data_point, label,-1);
@@ -652,7 +667,7 @@ namespace hnswlib {
             // Initialisation of the data and label
             memcpy(getExternalLabeLp(cur_c), &label, sizeof(labeltype));
             memcpy(getDataByInternalId(cur_c), data_point, data_size_);
-
+            label_lookup_[label] = cur_c;  // expected unique, if not will overwrite
 
             if (curlevel) {
                 linkLists_[cur_c] = (char *) malloc(size_links_per_element_ * curlevel + 1);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -20,7 +20,7 @@ namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
 
-    template<typename dist_t, typename data_t>
+    template<typename dist_t>
     class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     public:
 
@@ -600,6 +600,7 @@ namespace hnswlib {
             revSize_ = 1.0 / mult_;
             ef_ = 10;
             for (size_t i = 0; i < cur_element_count; i++) {
+                label_lookup_[getExternalLabel(i)]=i;
                 unsigned int linkListSize;
                 readBinaryPOD(input, linkListSize);
                 if (linkListSize == 0) {
@@ -617,6 +618,7 @@ namespace hnswlib {
             return;
         }
 
+        template<typename data_t>
         std::vector<data_t> getDataByLabel(labeltype label)
         {
           tableint label_c = label_lookup_[label];
@@ -645,6 +647,7 @@ namespace hnswlib {
                     throw std::runtime_error("The number of elements exceeds the specified limit");
                 };
                 cur_c = cur_element_count;
+                label_lookup_[label] = cur_c;  // expected unique, if not will overwrite
                 cur_element_count++;
             }
             std::unique_lock <std::mutex> lock_el(link_list_locks_[cur_c]);
@@ -667,7 +670,7 @@ namespace hnswlib {
             // Initialisation of the data and label
             memcpy(getExternalLabeLp(cur_c), &label, sizeof(labeltype));
             memcpy(getDataByInternalId(cur_c), data_point, data_size_);
-            label_lookup_[label] = cur_c;  // expected unique, if not will overwrite
+
 
             if (curlevel) {
                 linkLists_[cur_c] = (char *) malloc(size_links_per_element_ * curlevel + 1);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -20,7 +20,7 @@ namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
 
-    template<typename dist_t>
+    template<typename dist_t, typename data_t>
     class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     public:
 
@@ -617,13 +617,13 @@ namespace hnswlib {
             return;
         }
 
-        std::vector<dist_t> getDataByLabel(labeltype label)
+        std::vector<data_t> getDataByLabel(labeltype label)
         {
           tableint label_c = label_lookup_[label];
           char* data_ptrv = getDataByInternalId(label_c);
           size_t dim = *((size_t *) dist_func_param_);
-          std::vector<dist_t> data;
-          float* data_ptr = (float*) data_ptrv;
+          std::vector<data_t> data;
+          data_t* data_ptr = (data_t*) data_ptrv;
           for (int i = 0; i < dim; i++) {
             data.push_back(*data_ptr);
             data_ptr += 1;

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -216,7 +216,7 @@ public:
         }
     }
 
-    std::vector<std::vector<data_t>> GetDataReturnList(py::object ids_ = py::none()) {
+    std::vector<std::vector<data_t>> getDataReturnList(py::object ids_ = py::none()) {
         std::vector<size_t> ids;
         if (!ids_.is_none()) {
             py::array_t < size_t, py::array::c_style | py::array::forcecast > items(ids_);
@@ -233,6 +233,16 @@ public:
             data.push_back(appr_alg->template getDataByLabel<data_t>(id));
         }
         return data;
+    }
+
+    std::vector<unsigned int> getIdsList() {
+
+        std::vector<unsigned int> ids;
+
+        for(auto kv : appr_alg->label_lookup_) {
+            ids.push_back(kv.first);
+        }
+        return ids;
     }
 
     py::object knnQuery_return_numpy(py::object input, size_t k = 1, int num_threads = -1) {
@@ -360,7 +370,8 @@ PYBIND11_PLUGIN(hnswlib) {
         py::arg("ef_construction")=200, py::arg("random_seed")=100)
         .def("knn_query", &Index<float>::knnQuery_return_numpy, py::arg("data"), py::arg("k")=1, py::arg("num_threads")=-1)
         .def("add_items", &Index<float>::addItems, py::arg("data"), py::arg("ids") = py::none(), py::arg("num_threads")=-1)
-        .def("get_items", &Index<float, float>::GetDataReturnList, py::arg("ids") = py::none())
+        .def("get_items", &Index<float, float>::getDataReturnList, py::arg("ids") = py::none())
+        .def("get_ids_list", &Index<float>::getIdsList)
         .def("set_ef", &Index<float>::set_ef, py::arg("ef"))
         .def("set_num_threads", &Index<float>::set_num_threads, py::arg("num_threads"))
         .def("save_index", &Index<float>::saveIndex, py::arg("path_to_index"))

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -97,7 +97,7 @@ public:
             throw new std::runtime_error("The index is already initiated.");
         }
         cur_l = 0;
-        appr_alg = new hnswlib::HierarchicalNSW<dist_t, data_t>(l2space, maxElements, M, efConstruction, random_seed);
+        appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, maxElements, M, efConstruction, random_seed);
         index_inited = true;
         ep_added = false;
     }
@@ -119,7 +119,7 @@ public:
             std::cerr<<"Warning: Calling load_index for an already inited index. Old index is being deallocated.";
             delete appr_alg;
         }
-        appr_alg = new hnswlib::HierarchicalNSW<dist_t, data_t>(l2space, path_to_index, false, max_elements);
+        appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, max_elements);
 		cur_l = appr_alg->cur_element_count;
     }
 	void normalize_vector(float *data, float *norm_array){
@@ -230,7 +230,7 @@ public:
 
         std::vector<std::vector<data_t>> data;
         for (auto id : ids) {
-            data.push_back(appr_alg->getDataByLabel(id));
+            data.push_back(appr_alg->template getDataByLabel<data_t>(id));
         }
         return data;
     }
@@ -341,7 +341,7 @@ public:
     bool normalize;
     int num_threads_default;
     hnswlib::labeltype cur_l;
-    hnswlib::HierarchicalNSW<dist_t, data_t> *appr_alg;
+    hnswlib::HierarchicalNSW<dist_t> *appr_alg;
     hnswlib::SpaceInterface<float> *l2space;
 
     ~Index() {

--- a/python_bindings/tests/bindings_test.py
+++ b/python_bindings/tests/bindings_test.py
@@ -23,7 +23,7 @@ class RandomSelfTestCase(unittest.TestCase):
         # M - is tightly connected with internal dimensionality of the data
         #     stronlgy affects the memory consumption
 
-        p.init_index(max_elements=num_elements, ef_construction=100, M=16)
+        p.init_index(max_elements = num_elements, ef_construction = 100, M = 16)
 
         # Controlling the recall by setting ef:
         # higher ef leads to better accuracy, but slower search

--- a/python_bindings/tests/bindings_test_getdata.py
+++ b/python_bindings/tests/bindings_test_getdata.py
@@ -1,0 +1,46 @@
+import unittest
+
+
+class RandomSelfTestCase(unittest.TestCase):
+    def testGettingItems(self):
+        import hnswlib
+        import numpy as np
+
+        dim = 16
+        num_elements = 10000
+
+        # Generating sample data
+        data = np.float32(np.random.random((num_elements, dim)))
+        labels = np.arange(0, num_elements)
+
+        # Declaring index
+        p = hnswlib.Index(space='l2', dim=dim)  # possible options are l2, cosine or ip
+
+        # Initing index
+        # max_elements - the maximum number of elements, should be known beforehand
+        #     (probably will be made optional in the future)
+        #
+        # ef_construction - controls index search speed/build speed tradeoff
+        # M - is tightly connected with internal dimensionality of the data
+        #     stronlgy affects the memory consumption
+
+        p.init_index(max_elements=num_elements, ef_construction=100, M=16)
+
+        # Controlling the recall by setting ef:
+        # higher ef leads to better accuracy, but slower search
+        p.set_ef(300)
+
+        p.set_num_threads(4)  # by default using all available cores
+
+        # Before adding anything, getting any labels should fail
+        self.assertRaises(Exception, lambda: p.get_items(labels))
+
+        print("Adding all elements (%d)" % (len(data)))
+        p.add_items(data, labels)
+
+        # After adding them, all labels should be retrievable
+        returned_items = p.get_items(labels)
+        self.assertSequenceEqual(data.tolist(), returned_items)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python_bindings/tests/bindings_test_labels.py
+++ b/python_bindings/tests/bindings_test_labels.py
@@ -1,0 +1,89 @@
+import unittest
+
+
+class RandomSelfTestCase(unittest.TestCase):
+    def testRandomSelf(self):
+        import hnswlib
+        import numpy as np
+
+        dim = 16
+        num_elements = 10000
+
+        # Generating sample data
+        data = np.float32(np.random.random((num_elements, dim)))
+
+        # Declaring index
+        p = hnswlib.Index(space='l2', dim=dim)  # possible options are l2, cosine or ip
+
+        # Initing index
+        # max_elements - the maximum number of elements, should be known beforehand
+        #     (probably will be made optional in the future)
+        #
+        # ef_construction - controls index search speed/build speed tradeoff
+        # M - is tightly connected with internal dimensionality of the data
+        #     stronlgy affects the memory consumption
+
+        p.init_index(max_elements=num_elements, ef_construction=100, M=16)
+
+        # Controlling the recall by setting ef:
+        # higher ef leads to better accuracy, but slower search
+        p.set_ef(300)
+
+        p.set_num_threads(4)  # by default using all available cores
+
+        # We split the data in two batches:
+        data1 = data[:num_elements // 2]
+        data2 = data[num_elements // 2:]
+
+        print("Adding first batch of %d elements" % (len(data1)))
+        p.add_items(data1)
+
+        # Query the elements for themselves and measure recall:
+        labels, distances = p.knn_query(data1, k=1)
+
+        items=p.get_items(labels)
+
+        # Check the recall:
+        self.assertAlmostEqual(np.mean(labels.reshape(-1) == np.arange(len(data1))),1.0,3)
+
+        # Check that the returned element data is correct:
+        diff_with_gt_labels=np.max(np.abs(data1-items))
+        self.assertAlmostEqual(diff_with_gt_labels,0,1e-4)
+
+        # Serializing and deleting the index.
+        # We need the part to check that serialization is working properly.
+
+        index_path='first_half.bin'
+        print("Saving index to '%s'" % index_path)
+        p.save_index("first_half.bin")
+        print("Saved. Deleting...")
+        del p
+        print("Deleted")
+
+        # Reiniting, loading the index
+        print("Reiniting")
+        p = hnswlib.Index(space='l2', dim=dim)  # you can change the sa
+
+        print("\nLoading index from 'first_half.bin'\n")
+        p.load_index("first_half.bin")
+
+        print("Adding the second batch of %d elements" % (len(data2)))
+        p.add_items(data2)
+
+        # Query the elements for themselves and measure recall:
+        labels, distances = p.knn_query(data, k=1)
+        items=p.get_items(labels)
+
+        # Check the recall:
+        self.assertAlmostEqual(np.mean(labels.reshape(-1) == np.arange(len(data))),1.0,3)
+
+        # Check that the returned element data is correct:
+        diff_with_gt_labels=np.max(np.abs(data-items))
+        self.assertAlmostEqual(diff_with_gt_labels,0,1e-4)
+
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python_bindings/tests/bindings_test_labels.py
+++ b/python_bindings/tests/bindings_test_labels.py
@@ -81,6 +81,9 @@ class RandomSelfTestCase(unittest.TestCase):
         diff_with_gt_labels=np.max(np.abs(data-items))
         self.assertAlmostEqual(diff_with_gt_labels,0,1e-4)
 
+        # Checking that all labels are returned correcly:
+        sorted_labels=sorted(p.get_ids_list())
+        self.assertEqual(np.sum(~np.asarray(sorted_labels)==np.asarray(range(num_elements))),0)
 
 
 

--- a/python_bindings/tests/bindings_test_labels.py
+++ b/python_bindings/tests/bindings_test_labels.py
@@ -23,7 +23,7 @@ class RandomSelfTestCase(unittest.TestCase):
         # M - is tightly connected with internal dimensionality of the data
         #     stronlgy affects the memory consumption
 
-        p.init_index(max_elements=num_elements, ef_construction=100, M=16)
+        p.init_index(max_elements = num_elements, ef_construction = 100, M = 16)
 
         # Controlling the recall by setting ef:
         # higher ef leads to better accuracy, but slower search
@@ -48,7 +48,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Check that the returned element data is correct:
         diff_with_gt_labels=np.max(np.abs(data1-items))
-        self.assertAlmostEqual(diff_with_gt_labels,0,1e-4)
+        self.assertAlmostEqual(diff_with_gt_labels, 0, delta = 1e-4)
 
         # Serializing and deleting the index.
         # We need the part to check that serialization is working properly.
@@ -79,7 +79,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Check that the returned element data is correct:
         diff_with_gt_labels=np.max(np.abs(data-items))
-        self.assertAlmostEqual(diff_with_gt_labels,0,1e-4)
+        self.assertAlmostEqual(diff_with_gt_labels, 0, delta = 1e-4)
 
         # Checking that all labels are returned correcly:
         sorted_labels=sorted(p.get_ids_list())


### PR DESCRIPTION
Deletion is support in two ways: markDelete and recycle.

By markDeleted, a deleted flag is set at the higher 8 bits of the link size at level 0, no extra memory needed, the drawback is that the size of the links will be limited to 24bits, however, large enough in almost cases. 

By recycle(now named recycle_in_test), all the nodes marked deletion will be kicked out, the slots they occupied will be recorded in a similar way to linked list, by adding two vars: reusable_entry / reusable_tail, and reusing the memory for label to store the next.

recycle should be used after some "markDeleted"s, for a small number of deletion, only markDeleted would be enough, it depends on the scenario how to combine with recycle.

I did some testing, it seems ok for markDeleted, but not that sure for recycle.