### PR TITLE
setExternalLabel returns void

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -131,7 +131,7 @@ namespace hnswlib {
             return return_label;
         }
 
-        inline labeltype setExternalLabel(tableint internal_id, labeltype label) const {
+        inline void setExternalLabel(tableint internal_id, labeltype label) const {
             memcpy((data_level0_memory_ + internal_id * size_data_per_element_ + label_offset_), &label, sizeof(labeltype));
         }
 


### PR DESCRIPTION
howdy,

This patch fixes the prototype of `setExternalLabel`, which has no return value.

cheers, piem