### PR TITLE
Interface addpoint

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -40,7 +40,7 @@ namespace hnswlib {
 
         std::unordered_map<labeltype,size_t > dict_external_to_internal;
 
-        void addPoint(void *datapoint, labeltype label) {
+        void addPoint(const void *datapoint, labeltype label) {
 
             int idx;
             {

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -84,7 +84,10 @@ namespace hnswlib {
         }
 
 
-        std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *query_data, size_t k) const {
+        retType<dist_t> searchKnn(const void *query_data, size_t k) const {
+            retType<dist_t> result;
+            if (cur_element_count == 0) return result;
+
             std::priority_queue<std::pair<dist_t, labeltype >> topResults;
             for (int i = 0; i < k; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
@@ -103,7 +106,12 @@ namespace hnswlib {
                 }
 
             }
-            return topResults;
+            while (!topResults.empty()) {
+                auto each = topResults.top();
+                result.push(each);
+                topResults.pop();
+            }
+            return result;
         };
 
         void saveIndex(const std::string &location) {

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -484,6 +484,8 @@ namespace hnswlib {
 
 
         std::priority_queue<std::pair<dist_t, tableint>> searchKnnInternal(void *query_data, int k) {
+            std::priority_queue<std::pair<dist_t, tableint  >> top_candidates;
+            if (cur_element_count == 0) return top_candidates;
             tableint currObj = enterpoint_node_;
             dist_t curdist = fstdistfunc_(query_data, getDataByInternalId(enterpoint_node_), dist_func_param_);
 
@@ -510,8 +512,6 @@ namespace hnswlib {
                 }
             }
 
-
-            std::priority_queue<std::pair<dist_t, tableint  >> top_candidates;
             if (has_deletions_) {
                 std::priority_queue<std::pair<dist_t, tableint  >> top_candidates1=searchBaseLayerST<true>(currObj, query_data,
                                                                                                              ef_);
@@ -895,8 +895,9 @@ namespace hnswlib {
             return cur_c;
         };
 
-        retType<dist_t> searchKnn(const void *query_data, size_t k) const {
-            retType<dist_t> result;
+        std::priority_queue<std::pair<dist_t, labeltype >>
+        searchKnn(const void *query_data, size_t k) const {
+            std::priority_queue<std::pair<dist_t, labeltype >> result;
             if (cur_element_count == 0) return result;
 
             tableint currObj = enterpoint_node_;
@@ -948,6 +949,27 @@ namespace hnswlib {
             return result;
         };
 
+        template <typename Comp>
+        std::vector<std::pair<dist_t, labeltype>>
+        searchKnn(const void* query_data, size_t k, Comp comp) {
+            std::vector<std::pair<dist_t, labeltype>> result;
+            if (cur_element_count == 0) return result;
+
+            auto ret = searchKnn(query_data, k);
+
+            while (!ret.empty()) {
+                result.push_back(ret.top());
+                ret.pop();
+            }
+
+            if (result.size() > 1) {
+                if (!comp(result.front(), result.back())) {
+                    std::reverse(result.begin(), result.end());
+                }
+            }
+
+            return result;
+        }
 
     };
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -895,7 +895,10 @@ namespace hnswlib {
             return cur_c;
         };
 
-        std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *query_data, size_t k) const {
+        retType<dist_t> searchKnn(const void *query_data, size_t k) const {
+            retType<dist_t> result;
+            if (cur_element_count == 0) return result;
+
             tableint currObj = enterpoint_node_;
             dist_t curdist = fstdistfunc_(query_data, getDataByInternalId(enterpoint_node_), dist_func_param_);
 
@@ -934,16 +937,15 @@ namespace hnswlib {
                         currObj, query_data, std::max(ef_, k));
                 top_candidates.swap(top_candidates1);
             }
-            std::priority_queue<std::pair<dist_t, labeltype >> results;
             while (top_candidates.size() > k) {
                 top_candidates.pop();
             }
             while (top_candidates.size() > 0) {
                 std::pair<dist_t, tableint> rez = top_candidates.top();
-                results.push(std::pair<dist_t, labeltype>(rez.first, getExternalLabel(rez.second)));
+                result.push(std::pair<dist_t, labeltype>(rez.first, getExternalLabel(rez.second)));
                 top_candidates.pop();
             }
-            return results;
+            return result;
         };
 
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -150,7 +150,7 @@ namespace hnswlib {
         }
 
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
-        searchBaseLayer(tableint ep_id, void *data_point, int layer) {
+        searchBaseLayer(tableint ep_id, const void *data_point, int layer) {
             VisitedList *vl = visited_list_pool_->getFreeVisitedList();
             vl_type *visited_array = vl->mass;
             vl_type visited_array_tag = vl->curV;
@@ -371,7 +371,7 @@ namespace hnswlib {
             return (linklistsizeint *) (linkLists_[internal_id] + (level - 1) * size_links_per_element_);
         };
 
-        void mutuallyConnectNewElement(void *data_point, tableint cur_c,
+        void mutuallyConnectNewElement(const void *data_point, tableint cur_c,
                                        std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates,
                                        int level) {
 
@@ -779,11 +779,11 @@ namespace hnswlib {
             *((unsigned short int*)(ptr))=*((unsigned short int *)&size);
         }
 
-        void addPoint(void *data_point, labeltype label) {
+        void addPoint(const void *data_point, labeltype label) {
             addPoint(data_point, label,-1);
         }
 
-        tableint addPoint(void *data_point, labeltype label, int level) {
+        tableint addPoint(const void *data_point, labeltype label, int level) {
             tableint cur_c = 0;
             {
                 std::unique_lock <std::mutex> lock(cur_element_count_guard_);

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -24,11 +24,28 @@
 #endif
 
 #include <queue>
+#include <vector>
 
 #include <string.h>
 
 namespace hnswlib {
     typedef size_t labeltype;
+
+    template <typename T>
+    class pairGreater {
+    public:
+        bool operator()(const T& p1, const T& p2) {
+            return p1.first > p2.first;
+        }
+    };
+
+    template <typename T>
+    using retType = std::priority_queue<
+                std::pair<T, labeltype>,
+                std::vector<std::pair<T, labeltype>>,
+                pairGreater<std::pair<T, labeltype>>
+            >;
+
 
     template<typename T>
     static void writeBinaryPOD(std::ostream &out, const T &podRef) {
@@ -61,7 +78,7 @@ namespace hnswlib {
     class AlgorithmInterface {
     public:
         virtual void addPoint(const void *datapoint, labeltype label)=0;
-        virtual std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *, size_t) const = 0;
+        virtual retType<dist_t> searchKnn(const void *, size_t) const = 0;
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){
         }

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -39,14 +39,6 @@ namespace hnswlib {
         }
     };
 
-    template <typename T>
-    using retType = std::priority_queue<
-                std::pair<T, labeltype>,
-                std::vector<std::pair<T, labeltype>>,
-                pairGreater<std::pair<T, labeltype>>
-            >;
-
-
     template<typename T>
     static void writeBinaryPOD(std::ostream &out, const T &podRef) {
         out.write((char *) &podRef, sizeof(T));
@@ -78,7 +70,10 @@ namespace hnswlib {
     class AlgorithmInterface {
     public:
         virtual void addPoint(const void *datapoint, labeltype label)=0;
-        virtual retType<dist_t> searchKnn(const void *, size_t) const = 0;
+        virtual std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *, size_t) const = 0;
+        template <typename Comp>
+        std::vector<std::pair<dist_t, labeltype>> searchKnn(const void*, size_t, Comp) {
+        }
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){
         }

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -60,7 +60,7 @@ namespace hnswlib {
     template<typename dist_t>
     class AlgorithmInterface {
     public:
-        virtual void addPoint(void *datapoint, labeltype label)=0;
+        virtual void addPoint(const void *datapoint, labeltype label)=0;
         virtual std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *, size_t) const = 0;
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){

--- a/sift_1b.cpp
+++ b/sift_1b.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include <queue>
 #include <chrono>
 #include "hnswlib/hnswlib.h"
 
@@ -146,10 +147,10 @@ static size_t getCurrentRSS() {
 
 static void
 get_gt(unsigned int *massQA, unsigned char *massQ, unsigned char *mass, size_t vecsize, size_t qsize, L2SpaceI &l2space,
-       size_t vecdim, vector<retType<int>> &answers, size_t k) {
+       size_t vecdim, vector<std::priority_queue<std::pair<int, labeltype >>> &answers, size_t k) {
 
 
-    (vector<retType<int>>(qsize)).swap(answers);
+    (vector<std::priority_queue<std::pair<int, labeltype >>>(qsize)).swap(answers);
     DISTFUNC<int> fstdistfunc_ = l2space.get_dist_func();
     cout << qsize << "\n";
     for (int i = 0; i < qsize; i++) {
@@ -161,15 +162,15 @@ get_gt(unsigned int *massQA, unsigned char *massQ, unsigned char *mass, size_t v
 
 static float
 test_approx(unsigned char *massQ, size_t vecsize, size_t qsize, HierarchicalNSW<int> &appr_alg, size_t vecdim,
-            vector<retType<int>> &answers, size_t k) {
+            vector<std::priority_queue<std::pair<int, labeltype >>> &answers, size_t k) {
     size_t correct = 0;
     size_t total = 0;
     //uncomment to test in parallel mode:
     //#pragma omp parallel for
     for (int i = 0; i < qsize; i++) {
 
-        retType<int> result = appr_alg.searchKnn(massQ + vecdim * i, k);
-        retType<int> gt(answers[i]);
+        std::priority_queue<std::pair<int, labeltype >> result = appr_alg.searchKnn(massQ + vecdim * i, k);
+        std::priority_queue<std::pair<int, labeltype >> gt(answers[i]);
         unordered_set<labeltype> g;
         total += gt.size();
 
@@ -195,7 +196,7 @@ test_approx(unsigned char *massQ, size_t vecsize, size_t qsize, HierarchicalNSW<
 
 static void
 test_vs_recall(unsigned char *massQ, size_t vecsize, size_t qsize, HierarchicalNSW<int> &appr_alg, size_t vecdim,
-               vector<retType<int>> &answers, size_t k) {
+               vector<std::priority_queue<std::pair<int, labeltype >>> &answers, size_t k) {
     vector<size_t> efs;// = { 10,10,10,10,10 };
     for (int i = k; i < 30; i++) {
         efs.push_back(i);
@@ -230,7 +231,7 @@ inline bool exists_test(const std::string &name) {
 void sift_test1B() {
 	
 	
-	int subset_size_milllions = 1;
+	int subset_size_milllions = 200;
 	int efConstruction = 40;
 	int M = 16;
 	
@@ -350,7 +351,7 @@ void sift_test1B() {
     }
 
 
-    vector<retType<int>> answers;
+    vector<std::priority_queue<std::pair<int, labeltype >>> answers;
     size_t k = 1;
     cout << "Parsing gt:\n";
     get_gt(massQA, massQ, mass, vecsize, qsize, l2space, vecdim, answers, k);

--- a/sift_1b.cpp
+++ b/sift_1b.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <queue>
 #include <chrono>
 #include "hnswlib/hnswlib.h"
 

--- a/sift_1b.cpp
+++ b/sift_1b.cpp
@@ -147,10 +147,10 @@ static size_t getCurrentRSS() {
 
 static void
 get_gt(unsigned int *massQA, unsigned char *massQ, unsigned char *mass, size_t vecsize, size_t qsize, L2SpaceI &l2space,
-       size_t vecdim, vector<std::priority_queue<std::pair<int, labeltype >>> &answers, size_t k) {
+       size_t vecdim, vector<retType<int>> &answers, size_t k) {
 
 
-    (vector<std::priority_queue<std::pair<int, labeltype >>>(qsize)).swap(answers);
+    (vector<retType<int>>(qsize)).swap(answers);
     DISTFUNC<int> fstdistfunc_ = l2space.get_dist_func();
     cout << qsize << "\n";
     for (int i = 0; i < qsize; i++) {
@@ -162,15 +162,15 @@ get_gt(unsigned int *massQA, unsigned char *massQ, unsigned char *mass, size_t v
 
 static float
 test_approx(unsigned char *massQ, size_t vecsize, size_t qsize, HierarchicalNSW<int> &appr_alg, size_t vecdim,
-            vector<std::priority_queue<std::pair<int, labeltype >>> &answers, size_t k) {
+            vector<retType<int>> &answers, size_t k) {
     size_t correct = 0;
     size_t total = 0;
     //uncomment to test in parallel mode:
     //#pragma omp parallel for
     for (int i = 0; i < qsize; i++) {
 
-        std::priority_queue<std::pair<int, labeltype >> result = appr_alg.searchKnn(massQ + vecdim * i, k);
-        std::priority_queue<std::pair<int, labeltype >> gt(answers[i]);
+        retType<int> result = appr_alg.searchKnn(massQ + vecdim * i, k);
+        retType<int> gt(answers[i]);
         unordered_set<labeltype> g;
         total += gt.size();
 
@@ -196,7 +196,7 @@ test_approx(unsigned char *massQ, size_t vecsize, size_t qsize, HierarchicalNSW<
 
 static void
 test_vs_recall(unsigned char *massQ, size_t vecsize, size_t qsize, HierarchicalNSW<int> &appr_alg, size_t vecdim,
-               vector<std::priority_queue<std::pair<int, labeltype >>> &answers, size_t k) {
+               vector<retType<int>> &answers, size_t k) {
     vector<size_t> efs;// = { 10,10,10,10,10 };
     for (int i = k; i < 30; i++) {
         efs.push_back(i);
@@ -231,7 +231,7 @@ inline bool exists_test(const std::string &name) {
 void sift_test1B() {
 	
 	
-	int subset_size_milllions = 200;
+	int subset_size_milllions = 1;
 	int efConstruction = 40;
 	int M = 16;
 	
@@ -351,7 +351,7 @@ void sift_test1B() {
     }
 
 
-    vector<std::priority_queue<std::pair<int, labeltype >>> answers;
+    vector<retType<int>> answers;
     size_t k = 1;
     cout << "Parsing gt:\n";
     get_gt(massQA, massQ, mass, vecsize, qsize, l2space, vecdim, answers, k);


### PR DESCRIPTION
For new interface searchKnn,
1. virtual is not used because it's a template function
2. return a `vector<pair<dist_t, labeltype>>` because it is easier to use while keeps the order