### PR TITLE
currObj should be updated as the closest from all candidated.

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -406,7 +406,7 @@ namespace hnswlib {
                 top_candidates.pop();
             }
 
-            tableint next_closest_entry_point = selectedNeighbors[0];
+            tableint next_closest_entry_point = selectedNeighbors.back();
 
             {
                 linklistsizeint *ll_cur;


### PR DESCRIPTION
fix #115 `currObj` shuld be updated as the nearest node in `topCandidates`