### PR TITLE
Remove temlate interface searchKnn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,4 +23,6 @@ endif()
 
 add_executable(test_updates examples/updates_test.cpp)
 
+add_executable(searchKnnCloserFirst_test examples/searchKnnCloserFirst_test.cpp)
+
 target_link_libraries(main sift_test) 

--- a/examples/searchKnnCloserFirst_test.cpp
+++ b/examples/searchKnnCloserFirst_test.cpp
@@ -1,0 +1,84 @@
+// This is a test file for testing the interface
+//  >>> virtual std::vector<std::pair<dist_t, labeltype>>
+//  >>>    searchKnnCloserFirst(const void* query_data, size_t k) const;
+// of class AlgorithmInterface
+
+#include "../hnswlib/hnswlib.h"
+
+#include <assert.h>
+
+#include <vector>
+#include <iostream>
+
+namespace
+{
+
+using idx_t = hnswlib::labeltype;
+
+void test() {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+   
+    std::vector<float> data(n * d);
+    std::vector<float> query(nq * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib;
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+    for (idx_t i = 0; i < nq * d; ++i) {
+        query[i] = distrib(rng);
+    }
+      
+
+    hnswlib::L2Space space(d);
+    hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float>(&space, 2 * n);
+    hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * n);
+
+    for (size_t i = 0; i < n; ++i) {
+        alg_brute->addPoint(data.data() + d * i, i);
+        alg_hnsw->addPoint(data.data() + d * i, i);
+    }
+
+    // test searchKnnCloserFirst of BruteforceSearch
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_brute->searchKnn(p, k);
+        auto res = alg_brute->searchKnnCloserFirst(p, k);
+        assert(gd.size() == res.size());
+        size_t t = gd.size();
+        while (!gd.empty()) {
+            assert(gd.top() == res[--t]);
+            gd.pop();
+        }
+    }
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_hnsw->searchKnn(p, k);
+        auto res = alg_hnsw->searchKnnCloserFirst(p, k);
+        assert(gd.size() == res.size());
+        size_t t = gd.size();
+        while (!gd.empty()) {
+            assert(gd.top() == res[--t]);
+            gd.pop();
+        }
+    }
+    
+    delete alg_brute;
+    delete alg_hnsw;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "Testing ..." << std::endl;
+    test();
+    std::cout << "Test ok" << std::endl;
+
+    return 0;
+}

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -111,24 +111,6 @@ namespace hnswlib {
             return topResults;
         };
 
-        template <typename Comp>
-        std::vector<std::pair<dist_t, labeltype>>
-        searchKnn(const void* query_data, size_t k, Comp comp) {
-            std::vector<std::pair<dist_t, labeltype>> result;
-            if (cur_element_count == 0) return result;
-
-            auto ret = searchKnn(query_data, k);
-
-            while (!ret.empty()) {
-                result.push_back(ret.top());
-                ret.pop();
-            }
-            
-            std::sort(result.begin(), result.end(), comp);
-
-            return result;
-        }
-
         void saveIndex(const std::string &location) {
             std::ofstream output(location, std::ios::binary);
             std::streampos position;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -8,6 +8,7 @@
 #include <unordered_set>
 #include <list>
 
+#include <assert.h>
 
 namespace hnswlib {
     typedef unsigned int tableint;
@@ -406,7 +407,7 @@ namespace hnswlib {
                 top_candidates.pop();
             }
 
-            tableint next_closest_entry_point = selectedNeighbors[0];
+            tableint next_closest_entry_point = selectedNeighbors.back();
 
             {
                 linklistsizeint *ll_cur;
@@ -1156,23 +1157,18 @@ namespace hnswlib {
             return result;
         };
 
-        template <typename Comp>
-        std::vector<std::pair<dist_t, labeltype>>
-        searchKnn(const void* query_data, size_t k, Comp comp) {
-            std::vector<std::pair<dist_t, labeltype>> result;
-            if (cur_element_count == 0) return result;
-
-            auto ret = searchKnn(query_data, k);
-
-            while (!ret.empty()) {
-                result.push_back(ret.top());
-                ret.pop();
+        int searchKnn(const void* x,
+            int k, labeltype* labels, dist_t* dists = nullptr) const override {
+            if (labels == nullptr) return -1;
+            auto ret = searchKnn(x, k);
+            for (int i = k - 1; i >= 0; --i) {
+                if (dists) 
+                    dists[i] = ret.top().first;
+                labels[i] = ret.top().second;
             }
-
-            std::sort(result.begin(), result.end(), comp);
-
-            return result;
+            return 0;
         }
+
 
         void checkIntegrity(){
             int connections_checked=0;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -9,8 +9,6 @@
 #include <unordered_set>
 #include <list>
 
-#include <assert.h>
-
 namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -1157,19 +1157,6 @@ namespace hnswlib {
             return result;
         };
 
-        int searchKnn(const void* x,
-            int k, labeltype* labels, dist_t* dists = nullptr) const override {
-            if (labels == nullptr) return -1;
-            auto ret = searchKnn(x, k);
-            for (int i = k - 1; i >= 0; --i) {
-                if (dists) 
-                    dists[i] = ret.top().first;
-                labels[i] = ret.top().second;
-            }
-            return 0;
-        }
-
-
         void checkIntegrity(){
             int connections_checked=0;
             std::vector <int > inbound_connections_num(cur_element_count,0);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -407,7 +407,7 @@ namespace hnswlib {
                 top_candidates.pop();
             }
 
-            tableint next_closest_entry_point = selectedNeighbors.back();
+            tableint next_closest_entry_point = selectedNeighbors[0];
 
             {
                 linklistsizeint *ll_cur;

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -71,9 +71,8 @@ namespace hnswlib {
     public:
         virtual void addPoint(const void *datapoint, labeltype label)=0;
         virtual std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *, size_t) const = 0;
-        template <typename Comp>
-        std::vector<std::pair<dist_t, labeltype>> searchKnn(const void*, size_t, Comp) {
-        }
+        virtual int searchKnn(const void* x,
+            int k, labeltype* labels, dist_t* dists) const = 0;
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){
         }

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -71,13 +71,34 @@ namespace hnswlib {
     public:
         virtual void addPoint(const void *datapoint, labeltype label)=0;
         virtual std::priority_queue<std::pair<dist_t, labeltype >> searchKnn(const void *, size_t) const = 0;
-        virtual int searchKnn(const void* x,
-            int k, labeltype* labels, dist_t* dists) const = 0;
+
+        // Return k nearest neighbor in the order of closer fist
+        virtual std::vector<std::pair<dist_t, labeltype>>
+            searchKnnCloserFirst(const void* query_data, size_t k) const;
+
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){
         }
     };
 
+    template<typename dist_t>
+    std::vector<std::pair<dist_t, labeltype>>
+    AlgorithmInterface<dist_t>::searchKnnCloserFirst(const void* query_data, size_t k) const {
+        std::vector<std::pair<dist_t, labeltype>> result;
+
+        // here searchKnn returns the result in the order of further first
+        auto ret = searchKnn(query_data, k);
+        {
+            size_t sz = ret.size();
+            result.resize(sz);
+            while (!ret.empty()) {
+                result[--sz] = ret.top();
+                ret.pop();
+            }
+        }
+
+        return result;
+    }
 
 }
 


### PR DESCRIPTION
In issue #146, i add a templae interface 
https://github.com/nmslib/hnswlib/blob/3c6a84fb54a2a92dc4b7dc3e13dbae3d99892444/hnswlib/hnswlib.h#L74-L76
But it cannot be overrided. So I removed the template and make it a virtual function.