### PR TITLE
Adding cassert include in header to fix Bionic/gcc730 compilation

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <random>
 #include <stdlib.h>
+#include <assert.h>
 #include <unordered_set>
 #include <list>
 


### PR DESCRIPTION
Adding cassert include in header to fix compilation error on Ubuntu 18.04 with g++ 7.3.0. Fixes an issue reported by author in #229 