### PR TITLE
Fix some compiler warnings

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -26,7 +26,7 @@ namespace hnswlib {
         }
 
         HierarchicalNSW(SpaceInterface<dist_t> *s, size_t max_elements, size_t M = 16, size_t ef_construction = 200, size_t random_seed = 100) :
-                link_list_locks_(max_elements), element_levels_(max_elements), link_list_update_locks_(max_update_element_locks) {
+                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements) {
             max_elements_ = max_elements;
 
             has_deletions_=false;
@@ -764,7 +764,7 @@ namespace hnswlib {
             size_t dim = *((size_t *) dist_func_param_);
             std::vector<data_t> data;
             data_t* data_ptr = (data_t*) data_ptrv;
-            for (int i = 0; i < dim; i++) {
+            for (size_t i = 0; i < dim; i++) {
                 data.push_back(*data_ptr);
                 data_ptr += 1;
             }
@@ -868,8 +868,8 @@ namespace hnswlib {
 //                        continue;
 
                     std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidates;
-                    int size = sCand.find(neigh) == sCand.end() ? sCand.size() : sCand.size() - 1;
-                    int elementsToKeep = std::min(int(ef_construction_), size);
+                    size_t size = sCand.find(neigh) == sCand.end() ? sCand.size() : sCand.size() - 1;
+                    size_t elementsToKeep = std::min(ef_construction_, size);
                     for (auto&& cand : sCand) {
                         if (cand == neigh)
                             continue;
@@ -892,7 +892,7 @@ namespace hnswlib {
                         std::unique_lock <std::mutex> lock(link_list_locks_[neigh]);
                         linklistsizeint *ll_cur;
                         ll_cur = get_linklist_at_level(neigh, layer);
-                        int candSize = candidates.size();
+                        size_t candSize = candidates.size();
                         setListCount(ll_cur, candSize);
                         tableint *data = (tableint *) (ll_cur + 1);
                         for (size_t idx = 0; idx < candSize; idx++) {


### PR DESCRIPTION
This PR removes an initialization-order and several integer-kind comparison warnings.

I used the python bindings and `python setup.py test` to determine that I hadn't broken anything. I also didn't detect any slow down from using `size_t` instead of `int` to remove the integer comparison warnings. At the very least, the initialization reordering (line 29) should be totally safe.