### PR TITLE
Add pickle support to python bindings `Index` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For other spaces use the nmslib library https://github.com/nmslib/nmslib.
 #### Short API description
 * `hnswlib.Index(space, dim)` creates a non-initialized index an HNSW in space `space` with integer dimension `dim`.
 
-Index methods:
+`hnswlib.Index` methods:
 * `init_index(max_elements, ef_construction = 200, M = 16, random_seed = 100)` initializes the index from with no elements. 
     * `max_elements` defines the maximum number of elements that can be stored in the structure(can be increased/shrunk).
     * `ef_construction` defines a construction time/accuracy trade-off (see [ALGO_PARAMS.md](ALGO_PARAMS.md)).
@@ -76,7 +76,7 @@ Index methods:
 
 * `get_current_count()` - returns the current number of element stored in the index
 
-Read-only properties of Index class:
+Read-only properties of `hnswlib.Index` class:
 
 * `space` - name of the space (can be one of "l2", "ip", or "cosine"). 
 
@@ -90,7 +90,7 @@ Read-only properties of Index class:
 
 * `element_count` - number of items in the index. Equivalent to `p.get_current_count()`. 
 
-Properties of Index class that support reading and writing:
+Properties of `hnswlib.Index` that support reading and writing:
 
 * `ef` - parameter controlling query time/accuracy trade-off. Note that setting property `p.ef` prior to index initialization with `p.init_index(...)` will raise an error. 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,17 @@ Index methods:
 
 * `get_current_count()` - returns the current number of element stored in the index
 
-   
+Index properties:
+
+* `space` - name of the space (can be one of 'l2', 'ip', 'cosine'). This property is read-only.
+* `dim`   - dimensionality of the space. This property is read-only.
+* `M` - parameter that defines the maximum number of outgoing connections in the graph. This property is read-only.
+* `ef_construction` - parameter that controls speed/accuracy trade-off during the index construction. This property is read-only.
+* `ef` - parameter controlling query time/accuracy trade-off. This property supports read and write operations. Note: setting property `p.ef` prior to index initialization with `p.init_index(...)` will raise an error. 
+* `num_threads` - number of threads used in `add_items` or `knn_query` by default. This property supports read and write operations. Calling `p.set_num_threads(3)` is equivalent to `p.num_threads=3`.
+* `max_elements` - current capacity of the index (equivalent to `p.get_max_elements()`). This property is read-only.
+* `element_count` - number of items in the index (equivalent to `p.get_current_count()`). This property is read-only.
+
         
         
   
@@ -84,6 +94,7 @@ Index methods:
 ```python
 import hnswlib
 import numpy as np
+import pickle
 
 dim = 128
 num_elements = 10000
@@ -106,6 +117,12 @@ p.set_ef(50) # ef should always be > k
 
 # Query dataset, k - number of closest elements (returns 2 numpy arrays)
 labels, distances = p.knn_query(data, k = 1)
+
+# Index objects support pickling:
+p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p
+
+print(f"Index parameters: space={p_copy.space}, dim={p_copy.dim}, M={p_copy.M}, ef_construction={p_copy.ef_construction} ")
+print(f"                  ef={p_copy.ef}, element_count={p_copy.element_count}, max_elements={p_copy.max_elements}")
 ```
 
 An example with updates after serialization/deserialization:

--- a/README.md
+++ b/README.md
@@ -76,18 +76,27 @@ Index methods:
 
 * `get_current_count()` - returns the current number of element stored in the index
 
-Index properties:
+Read-only properties of Index class:
 
-* `space` - name of the space (can be one of 'l2', 'ip', 'cosine'). This property is read-only.
-* `dim`   - dimensionality of the space. This property is read-only.
-* `M` - parameter that defines the maximum number of outgoing connections in the graph. This property is read-only.
-* `ef_construction` - parameter that controls speed/accuracy trade-off during the index construction. This property is read-only.
-* `ef` - parameter controlling query time/accuracy trade-off. This property supports read and write operations. Note: setting property `p.ef` prior to index initialization with `p.init_index(...)` will raise an error. 
-* `num_threads` - number of threads used in `add_items` or `knn_query` by default. This property supports read and write operations. Calling `p.set_num_threads(3)` is equivalent to `p.num_threads=3`.
-* `max_elements` - current capacity of the index (equivalent to `p.get_max_elements()`). This property is read-only.
-* `element_count` - number of items in the index (equivalent to `p.get_current_count()`). This property is read-only.
+* `space` - name of the space (can be one of "l2", "ip", or "cosine"). 
 
-        
+* `dim`   - dimensionality of the space. 
+
+* `M` - parameter that defines the maximum number of outgoing connections in the graph. 
+
+* `ef_construction` - parameter that controls speed/accuracy trade-off during the index construction. 
+
+* `max_elements` - current capacity of the index (equivalent to `p.get_max_elements()`). 
+
+* `element_count` - number of items in the index (equivalent to `p.get_current_count()`). 
+
+Properties of Index class that support reading and writing:
+
+* `ef` - parameter controlling query time/accuracy trade-off. Note that setting property `p.ef` prior to index initialization with `p.init_index(...)` will raise an error. 
+
+* `num_threads` - default number of threads to use in `add_items` or `knn_query`. Note that calling `p.set_num_threads(3)` is equivalent to `p.num_threads=3`.
+
+  
         
   
 #### Python bindings examples
@@ -121,8 +130,12 @@ labels, distances = p.knn_query(data, k = 1)
 # Index objects support pickling:
 p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p
 
-print(f"Index parameters: space={p_copy.space}, dim={p_copy.dim}, M={p_copy.M}, ef_construction={p_copy.ef_construction} ")
-print(f"                  ef={p_copy.ef}, element_count={p_copy.element_count}, max_elements={p_copy.max_elements}")
+### Index parameters are exposed as class properties:
+print(f"Parameters passed to constructor:  space={p_copy.space}, dim={p_copy.dim}") 
+print(f"Index construction: M={p_copy.M}, ef_construction={p_copy.ef_construction}")
+print(f"Index size and capacity:   element_count={p_copy.element_count}, max_elements={p_copy.max_elements}")
+print(f"Search parameter: ef={p_copy.ef}")
+
 ```
 
 An example with updates after serialization/deserialization:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ p.set_ef(50) # ef should always be > k
 labels, distances = p.knn_query(data, k = 1)
 
 # Index objects support pickling:
-p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p
+p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p using pickle round-trip
 
 ### Index parameters are exposed as class properties:
 print(f"Parameters passed to constructor:  space={p_copy.space}, dim={p_copy.dim}") 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Read-only properties of `hnswlib.Index` class:
 
 Properties of `hnswlib.Index` that support reading and writing:
 
-* `ef` - parameter controlling query time/accuracy trade-off. Note that setting property `p.ef` prior to index initialization with `p.init_index(...)` will raise an error. 
+* `ef` - parameter controlling query time/accuracy trade-off.
 
-* `num_threads` - default number of threads to use in `add_items` or `knn_query`. Note that calling `p.set_num_threads(3)` is equivalent to setting `p.num_threads=3`.
+* `num_threads` - default number of threads to use in `add_items` or `knn_query`. Note that calling `p.set_num_threads(3)` is equivalent to `p.num_threads=3`.
 
   
         
@@ -127,7 +127,9 @@ p.set_ef(50) # ef should always be > k
 # Query dataset, k - number of closest elements (returns 2 numpy arrays)
 labels, distances = p.knn_query(data, k = 1)
 
-# Index objects support pickling:
+# Index objects support pickling
+# WARNING: serialization via pickle.dumps(p) or p.__getstate__() is NOT thread-safe with p.add_items method!
+# Note: ef parameter is included in serialization; random number generator is initialized with random_seeed on Index load
 p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p using pickle round-trip
 
 ### Index parameters are exposed as class properties:

--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ Read-only properties of Index class:
 
 * `ef_construction` - parameter that controls speed/accuracy trade-off during the index construction. 
 
-* `max_elements` - current capacity of the index (equivalent to `p.get_max_elements()`). 
+* `max_elements` - current capacity of the index. Equivalent to `p.get_max_elements()`. 
 
-* `element_count` - number of items in the index (equivalent to `p.get_current_count()`). 
+* `element_count` - number of items in the index. Equivalent to `p.get_current_count()`. 
 
 Properties of Index class that support reading and writing:
 
 * `ef` - parameter controlling query time/accuracy trade-off. Note that setting property `p.ef` prior to index initialization with `p.init_index(...)` will raise an error. 
 
-* `num_threads` - default number of threads to use in `add_items` or `knn_query`. Note that calling `p.set_num_threads(3)` is equivalent to `p.num_threads=3`.
+* `num_threads` - default number of threads to use in `add_items` or `knn_query`. Note that calling `p.set_num_threads(3)` is equivalent to setting `p.num_threads=3`.
 
   
         
@@ -133,8 +133,8 @@ p_copy = pickle.loads(pickle.dumps(p)) # creates a copy of index p using pickle 
 ### Index parameters are exposed as class properties:
 print(f"Parameters passed to constructor:  space={p_copy.space}, dim={p_copy.dim}") 
 print(f"Index construction: M={p_copy.M}, ef_construction={p_copy.ef_construction}")
-print(f"Index size and capacity:   element_count={p_copy.element_count}, max_elements={p_copy.max_elements}")
-print(f"Search parameter: ef={p_copy.ef}")
+print(f"Index size is {p_copy.element_count} and index capacity is {p_copy.max_elements}")
+print(f"Search speed/quality trade-off parameter: ef={p_copy.ef}")
 
 ```
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -874,7 +874,7 @@ namespace hnswlib {
                     for (auto&& cand : sCand) {
                         if (cand == neigh)
                             continue;
-                        
+
                         dist_t distance = fstdistfunc_(getDataByInternalId(neigh), getDataByInternalId(cand), dist_func_param_);
                         if (candidates.size() < elementsToKeep) {
                             candidates.emplace(distance, cand);
@@ -1137,7 +1137,7 @@ namespace hnswlib {
             }
 
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
-            if (has_deletions_) {                
+            if (has_deletions_) {
                 top_candidates=searchBaseLayerST<true,true>(
                         currObj, query_data, std::max(ef_, k));
             }
@@ -1186,19 +1186,19 @@ namespace hnswlib {
                     std::unordered_set<tableint> s;
                     for (int j=0; j<size; j++){
                         assert(data[j] > 0);
-                        assert(data[j] < cur_element_count);                                                
+                        assert(data[j] < cur_element_count);
                         assert (data[j] != i);
                         inbound_connections_num[data[j]]++;
                         s.insert(data[j]);
                         connections_checked++;
-                        
+
                     }
                     assert(s.size() == size);
                 }
             }
             if(cur_element_count > 1){
                 int min1=inbound_connections_num[0], max1=inbound_connections_num[0];
-                for(int i=0; i < cur_element_count; i++){                
+                for(int i=0; i < cur_element_count; i++){
                     assert(inbound_connections_num[i] > 0);
                     min1=std::min(inbound_connections_num[i],min1);
                     max1=std::max(inbound_connections_num[i],max1);
@@ -1206,7 +1206,7 @@ namespace hnswlib {
                 std::cout << "Min inbound: " << min1 << ", Max inbound:" << max1 << "\n";
             }
             std::cout << "integrity ok, checked " << connections_checked << " connections\n";
-            
+
         }
 
     };

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -637,7 +637,6 @@ namespace hnswlib {
             if (!input.is_open())
                 throw std::runtime_error("Cannot open file");
 
-
             // get file size:
             input.seekg(0,input.end);
             std::streampos total_filesize=input.tellg();

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -26,10 +26,6 @@ namespace hnswlib {
             loadIndex(location, s, max_elements);
         }
 
-        HierarchicalNSW(SpaceInterface<dist_t> *s, std::istream & input, bool nmslib = false, size_t max_elements=0) {
-            loadIndexFromStream(input, s, max_elements);
-        }
-
         HierarchicalNSW(SpaceInterface<dist_t> *s, size_t max_elements, size_t M = 16, size_t ef_construction = 200, size_t random_seed = 100) :
                 link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements) {
             max_elements_ = max_elements;
@@ -60,6 +56,8 @@ namespace hnswlib {
             cur_element_count = 0;
 
             visited_list_pool_ = new VisitedListPool(1, max_elements);
+
+
 
             //initializations for special treatment of the first node
             enterpoint_node_ = -1;
@@ -104,8 +102,6 @@ namespace hnswlib {
         double mult_, revSize_;
         int maxlevel_;
 
-        std::mutex global;
-        size_t ef_;
 
         VisitedListPool *visited_list_pool_;
         std::mutex cur_element_count_guard_;
@@ -515,6 +511,8 @@ namespace hnswlib {
             return next_closest_entry_point;
         }
 
+        std::mutex global;
+        size_t ef_;
 
         void setEf(size_t ef) {
             ef_ = ef;
@@ -600,7 +598,10 @@ namespace hnswlib {
             max_elements_=new_max_elements;
 
         }
-        void saveIndexToStream(std::ostream &output) {
+
+        void saveIndex(const std::string &location) {
+            std::ofstream output(location, std::ios::binary);
+            std::streampos position;
 
             writeBinaryPOD(output, offsetLevel0_);
             writeBinaryPOD(output, max_elements_);
@@ -625,17 +626,17 @@ namespace hnswlib {
                 if (linkListSize)
                     output.write(linkLists_[i], linkListSize);
             }
-
-        }
-
-        void saveIndex(const std::string &location) {
-            std::ofstream output(location, std::ios::binary);
-            std::streampos position;
-            saveIndexToStream(output);
             output.close();
         }
 
-        void loadIndexFromStream(std::istream & input, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
+        void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
+
+
+            std::ifstream input(location, std::ios::binary);
+
+            if (!input.is_open())
+                throw std::runtime_error("Cannot open file");
+
 
             // get file size:
             input.seekg(0,input.end);
@@ -662,11 +663,13 @@ namespace hnswlib {
             readBinaryPOD(input, mult_);
             readBinaryPOD(input, ef_construction_);
 
+
             data_size_ = s->get_data_size();
             fstdistfunc_ = s->get_dist_func();
             dist_func_param_ = s->get_dist_func_param();
 
             auto pos=input.tellg();
+
 
             /// Optional - check if index is ok:
 
@@ -693,10 +696,14 @@ namespace hnswlib {
 
             input.seekg(pos,input.beg);
 
+
             data_level0_memory_ = (char *) malloc(max_elements * size_data_per_element_);
             if (data_level0_memory_ == nullptr)
                 throw std::runtime_error("Not enough memory: loadIndex failed to allocate level0");
             input.read(data_level0_memory_, cur_element_count * size_data_per_element_);
+
+
+
 
             size_links_per_element_ = maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
 
@@ -707,6 +714,7 @@ namespace hnswlib {
 
 
             visited_list_pool_ = new VisitedListPool(1, max_elements);
+
 
             linkLists_ = (char **) malloc(sizeof(void *) * max_elements);
             if (linkLists_ == nullptr)
@@ -738,19 +746,8 @@ namespace hnswlib {
                     has_deletions_=true;
             }
 
-
-            return;
-        }
-
-
-
-        void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
-            std::ifstream input(location, std::ios::binary);
-            if (!input.is_open())
-                throw std::runtime_error("Cannot open file");
-
-            loadIndexFromStream(input, s, max_elements_i);
             input.close();
+
             return;
         }
 
@@ -877,7 +874,7 @@ namespace hnswlib {
                     for (auto&& cand : sCand) {
                         if (cand == neigh)
                             continue;
-
+                        
                         dist_t distance = fstdistfunc_(getDataByInternalId(neigh), getDataByInternalId(cand), dist_func_param_);
                         if (candidates.size() < elementsToKeep) {
                             candidates.emplace(distance, cand);
@@ -1140,7 +1137,7 @@ namespace hnswlib {
             }
 
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
-            if (has_deletions_) {
+            if (has_deletions_) {                
                 top_candidates=searchBaseLayerST<true,true>(
                         currObj, query_data, std::max(ef_, k));
             }
@@ -1189,19 +1186,19 @@ namespace hnswlib {
                     std::unordered_set<tableint> s;
                     for (int j=0; j<size; j++){
                         assert(data[j] > 0);
-                        assert(data[j] < cur_element_count);
+                        assert(data[j] < cur_element_count);                                                
                         assert (data[j] != i);
                         inbound_connections_num[data[j]]++;
                         s.insert(data[j]);
                         connections_checked++;
-
+                        
                     }
                     assert(s.size() == size);
                 }
             }
             if(cur_element_count > 1){
                 int min1=inbound_connections_num[0], max1=inbound_connections_num[0];
-                for(int i=0; i < cur_element_count; i++){
+                for(int i=0; i < cur_element_count; i++){                
                     assert(inbound_connections_num[i] > 0);
                     min1=std::min(inbound_connections_num[i],min1);
                     max1=std::max(inbound_connections_num[i],max1);
@@ -1209,7 +1206,7 @@ namespace hnswlib {
                 std::cout << "Min inbound: " << min1 << ", Max inbound:" << max1 << "\n";
             }
             std::cout << "integrity ok, checked " << connections_checked << " connections\n";
-
+            
         }
 
     };

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -285,7 +285,7 @@ public:
     }
 
 
-    py::tuple getAnnData() const { /* WARNING: Index<float>::getAnnData is not thread-safe with Index<float>::addItems */
+    py::tuple getAnnData() const { /* WARNING: Index::getAnnData is not thread-safe with Index::addItems */
       
       std::unique_lock <std::mutex> templock(appr_alg->global);
 
@@ -411,8 +411,8 @@ public:
       if (py::int_(Index<float>::ser_version) != t[0].cast<int>()) // check serialization version 
           throw std::runtime_error("Serialization version mismatch!");
 
-      py::tuple index_params=t[1].cast<py::tuple>(); /* TODO: convert this py::tuple to py::dict */
-      py::tuple ann_params=t[2].cast<py::tuple>();   /* TODO: convert this py::tuple to py::dict */
+      py::tuple index_params=t[1].cast<py::tuple>(); /* TODO: convert index_params from py::tuple to py::dict */
+      py::tuple ann_params=t[2].cast<py::tuple>();   /* TODO: convert ann_params from py::tuple to py::dict */
 
       auto space_name_=index_params[0].cast<std::string>();
       auto dim_=index_params[1].cast<int>();
@@ -421,7 +421,7 @@ public:
       Index<float> *new_index = new Index<float>(index_params[0].cast<std::string>(), index_params[1].cast<int>());
 
       /*  TODO: deserialize state of random generators into new_index->level_generator_ and new_index->update_probability_generator_  */
-      /*        for full reproducibility / state of generators is serialized inside Index<float>::getIndexParams                      */
+      /*        for full reproducibility / state of generators is serialized inside Index::getIndexParams                      */
       new_index->seed = index_params[6].cast<size_t>();
 
       if (index_inited_){
@@ -442,13 +442,13 @@ public:
     }
 
     static Index<float> * createFromIndex(const Index<float> & index) {
-        /* WARNING:     Index<float>::getIndexParams is not thread-safe with Index<float>::addItems */
+        /* WARNING:     Index::getIndexParams is not thread-safe with Index::addItems */
         return createFromParams(index.getIndexParams()); 
     }
 
     
     void setAnnData(const py::tuple t) {
-      /* WARNING: Index<float>::setAnnData is not thread-safe with Index<float>::addItems */
+      /* WARNING: Index::setAnnData is not thread-safe with Index::addItems */
       
       std::unique_lock <std::mutex> templock(appr_alg->global);
 
@@ -641,7 +641,7 @@ PYBIND11_PLUGIN(hnswlib) {
 
         py::class_<Index<float>>(m, "Index")
         .def(py::init(&Index<float>::createFromParams), py::arg("params")) 
-           /* WARNING: Index<float>::createFromIndex is not thread-safe with Index<float>::addItems */
+           /* WARNING: Index::createFromIndex is not thread-safe with Index::addItems */
         .def(py::init(&Index<float>::createFromIndex), py::arg("index")) 
         .def(py::init<const std::string &, const int>(), py::arg("space"), py::arg("dim"))
         .def("init_index", &Index<float>::init_new_index, py::arg("max_elements"), py::arg("M")=16, py::arg("ef_construction")=200, py::arg("random_seed")=100)
@@ -683,7 +683,7 @@ PYBIND11_PLUGIN(hnswlib) {
         .def(py::pickle(
             [](const Index<float> &ind) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                /* WARNING: Index<float>::getIndexParams is not thread-safe with Index<float>::addItems */
+                /* WARNING: Index::getIndexParams is not thread-safe with Index::addItems */
                 return ind.getIndexParams();
             },
             [](py::tuple t) { // __setstate__

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -410,7 +410,7 @@ PYBIND11_PLUGIN(hnswlib) {
         .def("load_index", &Index<float>::loadIndex, py::arg("path_to_index"), py::arg("max_elements")=0)
         .def("mark_deleted", &Index<float>::markDeleted, py::arg("label"))
         .def("resize_index", &Index<float>::resizeIndex, py::arg("new_size"))
-        .def_readonly("space_name", &Index<float>::space_name)
+        .def_readonly("space", &Index<float>::space_name)
         .def_readonly("dim", &Index<float>::dim)
         .def_readwrite("num_threads", &Index<float>::num_threads_default)
         .def_property("ef",

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -393,12 +393,14 @@ public:
 
     py::tuple getIndexParams() const {
         /*  TODO: serialize state of random generators appr_alg->level_generator_ and appr_alg->update_probability_generator_  */
-        /*        for full reproducibility / to avoid re-initializing generators inside Index<float>::createFromParams         */
+        /*        for full reproducibility / to avoid re-initializing generators inside Index::createFromParams         */
         
         return py::make_tuple(py::int_(Index<float>::ser_version), // serialization version 
+        
+                              /* TODO: convert the following two py::tuple's to py::dict */
                               py::make_tuple(space_name, dim, index_inited, ep_added, normalize, num_threads_default, seed, default_ef),
-                              index_inited == true ? getAnnData() : py::make_tuple());
-                           /* WARNING: Index<float>::getAnnData is not thread-safe with Index<float>::addItems */
+                              index_inited == true ? getAnnData() : py::make_tuple()); /* WARNING: Index::getAnnData is not thread-safe with Index::addItems */
+                           
                               
 
     }
@@ -409,8 +411,8 @@ public:
       if (py::int_(Index<float>::ser_version) != t[0].cast<int>()) // check serialization version 
           throw std::runtime_error("Serialization version mismatch!");
 
-      py::tuple index_params=t[1].cast<py::tuple>();
-      py::tuple ann_params=t[2].cast<py::tuple>();
+      py::tuple index_params=t[1].cast<py::tuple>(); /* TODO: convert this py::tuple to py::dict */
+      py::tuple ann_params=t[2].cast<py::tuple>();   /* TODO: convert this py::tuple to py::dict */
 
       auto space_name_=index_params[0].cast<std::string>();
       auto dim_=index_params[1].cast<int>();

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -360,7 +360,7 @@ public:
     }
 
 
-    static Index<float> * createFromParams(const py::tuple t) {
+    static Index<float> * createFromParams(const py::tuple & t) {
       py::tuple index_params=t[0].cast<py::tuple>();
       py::tuple ann_params=t[1].cast<py::tuple>();
 
@@ -394,7 +394,7 @@ public:
       return createFromParams(index.getIndexParams());
     }
 
-    void setAnnData(const py::tuple t) {
+    void setAnnData(const py::tuple & t) {
 
       std::unique_lock <std::mutex> templock(appr_alg->global);
 
@@ -471,7 +471,7 @@ public:
     }
 
 
-    py::object knnQuery_return_numpy(py::object input, size_t k = 1, int num_threads = -1) {
+    py::object knnQuery_return_numpy(py::object & input, size_t k = 1, int num_threads = -1) {
 
         py::array_t < dist_t, py::array::c_style | py::array::forcecast > items(input);
         auto buffer = items.request();
@@ -636,7 +636,7 @@ PYBIND11_PLUGIN(hnswlib) {
                 /* Return a tuple that fully encodes the state of the object */
                 return ind.getIndexParams();
             },
-            [](py::tuple t) { // __setstate__
+            [](py::tuple & t) { // __setstate__
                 if (t.size() != 2)
                     throw std::runtime_error("Invalid state!");
                 return Index<float>::createFromParams(t);

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -273,7 +273,7 @@ public:
                 std::vector<float> norm_array(num_threads * dim);
                 ParallelFor(start, rows, num_threads, [&](size_t row, size_t threadId) {
                     // normalize vector:
-					           size_t start_idx = threadId * dim;
+                    size_t start_idx = threadId * dim;
                     normalize_vector((float *) items.data(row), (norm_array.data()+start_idx));
 
                     size_t id = ids.size() ? ids.at(row) : (cur_l+row);
@@ -339,7 +339,6 @@ public:
         unsigned int linkListSize = appr_alg->element_levels_[i] > 0 ? appr_alg->size_links_per_element_ * appr_alg->element_levels_[i] : 0;
         if (linkListSize){
           memcpy(link_list_npy+(link_npy_stride * i), appr_alg->linkLists_[i], linkListSize);
-          // std::cout << linkListSize << " " << appr_alg->maxlevel_ << " " << appr_alg->element_levels_[i] << " generator: " << appr_alg->level_generator_ << std::endl;
         }
       }
 
@@ -368,12 +367,12 @@ public:
                             appr_alg->size_links_per_element_,
                             appr_alg->label_lookup_,
                             appr_alg->element_levels_,
-                            py::array_t<char>(
+                            new py::array_t<char>(
                                     {level0_npy_size}, // shape
                                     {sizeof(char)}, // C-style contiguous strides for double
                                     data_level0_npy, // the data pointer
                                     free_when_done_l0),
-                            py::array_t<char>(
+                            new py::array_t<char>(
                                     {link_npy_size}, // shape
                                     {sizeof(char)}, // C-style contiguous strides for double
                                     link_list_npy, // the data pointer
@@ -546,7 +545,7 @@ public:
                                 float *data= (float *) items.data(row);
 
                                 size_t start_idx = threadId * dim;
-			                          normalize_vector((float *) items.data(row), (norm_array.data()+start_idx));
+                                normalize_vector((float *) items.data(row), (norm_array.data()+start_idx));
 
                                 std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result = appr_alg->searchKnn(
                                         (void *) (norm_array.data()+start_idx), k);
@@ -633,15 +632,9 @@ PYBIND11_PLUGIN(hnswlib) {
             return index.index_inited ? index.appr_alg->ef_ : index.default_ef;
           },
           [](Index<float> & index, const size_t ef_) {
-            // index.set_ef(ef_);
             index.default_ef=ef_;
             if (index.appr_alg)
               index.appr_alg->ef_ = ef_;
-
-            // if (index.index_inited)
-              // index.appr_alg->ef_ = ef_;
-            // else
-              // throw std::runtime_error("must call init_index prior to setting ef parameter");
         })
         .def_property_readonly("max_elements", [](const Index<float> & index) {
             return index.index_inited ? index.appr_alg->max_elements_ : 0;
@@ -672,109 +665,8 @@ PYBIND11_PLUGIN(hnswlib) {
           index.appr_alg->checkIntegrity();
           std::cout<< index.default_ef << " " << index.appr_alg->ef_ << std::endl;
           return index.appr_alg->ef_;
-              // return index.getIndexParams();
-              // return index.appr_alg->element_levels_;
-
-              // std::stringstream output(std::stringstream::out|std::stringstream::binary);
-              //
-              // .def("get_params", &Index<float>::getIndexParams)
-              // .def("set_params",  &Index<float>::setIndexParams,  py::arg("t"))// [](Index<float> & index, py::tuple t) {
-              //
-              // if (index.index_inited)
-              //   index.saveIndexToStream(output);
-              //
-              // /* Return a tuple that fully encodes the state of the object */
-              // return py::make_tuple(index.space_name, index.dim,
-              //                       index.index_inited, index.ep_added,
-              //                       index.normalize, index.num_threads_default,
-              //                       py::bytes(output.str()),
-              //                       index.index_inited == false ? 10 : index.appr_alg->ef_,
-              //                       index.index_inited == false ? 0  : index.appr_alg->max_elements_,
-              //                       index.index_inited == false ? 0  : index.appr_alg->cur_element_count
-              //                     );
         })
 
-
-                    // .def(py::pickle(
-        //     [](const Index<float> & index) { // __getstate__
-        //         /* Return a tuple that fully encodes the state of the object */
-        //         return index.getIndexParams();
-        //     },
-        //     [](Index<float> & index, py::tuple t) { // __setstate__
-        //         if (t.size() != 2)
-        //             throw std::runtime_error("Invalid state!");
-        //
-        //         /* Invoke Index constructor (need to use in-place version) */
-        //         // py::tuple index_params = t[0].cast<py::tuple>();
-        //         // Index<float> new_index(index_params[0].cast<std::string>(), index_params[1].cast<int>());
-        //         index.setIndexParams(t);
-        //         return  index;
-        //
-        //         /* Create a new C++ instance */
-        //         // Pickleable p(t[0].cast<std::string>());
-        //
-        //         /* Assign any additional state */
-        //         // p.setExtra(t[1].cast<int>());
-        //
-        //         // return p;
-        //     }
-        // ))
-
-        // .def("__getstate__", &Index<float>::getIndexParams) // __getstate__
-        // .def("__setstate__", &Index<float>::setIndexParams)  // __setstate__
-          // .def("__setstate__", [](Index<float> & index, py::tuple t) { // __setstate__
-            // py::tuple index_params = t[0].cast<py::tuple>();
-            // new (&index) Index<float>(index_params[0].cast<std::string>(), index_params[1].cast<int>());
-            // index.setIndexParams(t);
-            // return index;
-        // })
-        // .def("__getstate__", [](const Index<float> & index) { // __getstate__
-        //       return index.getIndexParams();
-        //
-        //       // std::stringstream output(std::stringstream::out|std::stringstream::binary);
-        //       //
-        //       // .def("get_params", &Index<float>::getIndexParams)
-        //       // .def("set_params",  &Index<float>::setIndexParams,  py::arg("t"))// [](Index<float> & index, py::tuple t) {
-        //       //
-        //       // if (index.index_inited)
-        //       //   index.saveIndexToStream(output);
-        //       //
-        //       // /* Return a tuple that fully encodes the state of the object */
-        //       // return py::make_tuple(index.space_name, index.dim,
-        //       //                       index.index_inited, index.ep_added,
-        //       //                       index.normalize, index.num_threads_default,
-        //       //                       py::bytes(output.str()),
-        //       //                       index.index_inited == false ? 10 : index.appr_alg->ef_,
-        //       //                       index.index_inited == false ? 0  : index.appr_alg->max_elements_,
-        //       //                       index.index_inited == false ? 0  : index.appr_alg->cur_element_count
-        //       //                     );
-        // })
-        // .def("set_state", [](Index<float> & index, py::tuple t) { // __setstate__
-        //   index.setIndexParams(t);
-        // })
-        //
-        // .def("__setstate__", [](Index<float> & index, py::tuple t) { // __setstate__
-        //       // delete &index;
-        //       /* Invoke Index constructor (need to use in-place version) */
-        //       // py::tuple index_params = t[0].cast<py::tuple>();
-        //       // new (&index) Index<float>(index_params[0].cast<std::string>(), index_params[1].cast<int>());
-        //       index.setIndexParams(t);
-        //       // if (t.size() != 10)
-        //       //     throw std::runtime_error("Invalid state!");
-        //       //
-        //
-        //       // index.index_inited=t[2].cast<bool>();
-        //       // index.ep_added=t[3].cast<bool>();
-        //       // index.normalize=t[4].cast<bool>();
-        //       // index.num_threads_default=t[5].cast<int>();
-        //       //
-        //       // if (index.index_inited){
-        //       //   std::stringstream input(t[6].cast<std::string>(), std::stringstream::in|std::stringstream::binary);
-        //       //   index.loadIndexFromStream(input, t[8].cast<int>()); // use max_elements from state
-        //       //   index.appr_alg->ef_=(t[7].cast<size_t>());
-        //       // }
-        //
-        // })
         .def("__repr__", [](const Index<float> &a) {
             return "<hnswlib.Index(space='" + a.space_name + "', dim="+std::to_string(a.dim)+")>";
         });

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -5,6 +5,8 @@
 #include "hnswlib/hnswlib.h"
 #include <thread>
 #include <atomic>
+#include <stdlib.h>
+#include <assert.h>
 
 namespace py = pybind11;
 
@@ -71,6 +73,44 @@ inline void ParallelFor(size_t start, size_t end, size_t numThreads, Function fn
 
 }
 
+//
+// std::priority_queue<std::pair<dist_t, labeltype >>
+// searchKnn(const void *query_data, size_t k) const {
+//     std::priority_queue<std::pair<dist_t, labeltype >> result;
+//     if (cur_element_count == 0) return result;
+//
+//     tableint currObj = enterpoint_node_;
+//     dist_t curdist = fstdistfunc_(query_data, getDataByInternalId(enterpoint_node_), dist_func_param_);
+//
+//     for (int level = maxlevel_; level > 0; level--) {
+//         bool changed = true;
+//         while (changed) {
+//             changed = false;
+//             unsigned int *data;
+//
+//             data = (unsigned int *) get_linklist(currObj, level);
+//             int size = getListCount(data);
+//             metric_hops++;
+//             metric_distance_computations+=size;
+//
+//             tableint *datal = (tableint *) (data + 1);
+//             for (int i = 0; i < size; i++) {
+//                 tableint cand = datal[i];
+//                 if (cand < 0 || cand > max_elements_)
+//                     throw std::runtime_error("cand error");
+//                 dist_t d = fstdistfunc_(query_data, getDataByInternalId(cand), dist_func_param_);
+//
+//                 if (d < curdist) {
+//                     curdist = d;
+//                     currObj = cand;
+//                     changed = true;
+//                 }
+//             }
+//         }
+//     }
+//
+
+
 template<typename dist_t, typename data_t=float>
 class Index {
 public:
@@ -91,6 +131,27 @@ public:
     ep_added = true;
     index_inited = false;
     num_threads_default = std::thread::hardware_concurrency();
+
+    default_ef=10;
+
+  }
+  std::string space_name;
+  int dim;
+  size_t seed;
+  size_t default_ef;
+
+  bool index_inited;
+  bool ep_added;
+  bool normalize;
+  int num_threads_default;
+  hnswlib::labeltype cur_l;
+  hnswlib::HierarchicalNSW<dist_t> *appr_alg;
+  hnswlib::SpaceInterface<float> *l2space;
+
+  ~Index() {
+      delete l2space;
+      if (appr_alg)
+          delete appr_alg;
   }
 
     void init_new_index(const size_t maxElements, const size_t M, const size_t efConstruction, const size_t random_seed) {
@@ -101,11 +162,14 @@ public:
         appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, maxElements, M, efConstruction, random_seed);
         index_inited = true;
         ep_added = false;
+        appr_alg->ef_ = default_ef;
+        seed=random_seed;
     }
 
 
-
     void set_ef(size_t ef) {
+      default_ef=ef;
+      if (appr_alg)
         appr_alg->ef_ = ef;
     }
 
@@ -116,18 +180,6 @@ public:
 
     void saveIndex(const std::string &path_to_index) {
         appr_alg->saveIndex(path_to_index);
-    }
-    void saveIndexToStream(std::ostream & output) const {
-        appr_alg->saveIndexToStream(output);
-    }
-
-    void loadIndexFromStream(std::istream & input, size_t max_elements) {
-      if (appr_alg) {
-          std::cerr<<"Warning: Calling load_index from istream for an already inited index. Old index is being deallocated." << std::endl;
-          delete appr_alg;
-      }
-      appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, input, false, max_elements);
-      cur_l = appr_alg->cur_element_count;
     }
 
     void loadIndex(const std::string &path_to_index, size_t max_elements) {
@@ -261,6 +313,183 @@ public:
         return ids;
     }
 
+    inline void assert_true(bool expr, const std::string & msg) {
+      if (expr == false)
+        throw std::runtime_error("assert failed: "+msg);
+      return;
+    }
+
+
+    py::tuple getAnnData() const {
+
+      unsigned int level0_npy_size = appr_alg->cur_element_count * appr_alg->size_data_per_element_;
+      unsigned int link_npy_size = appr_alg->cur_element_count * appr_alg->maxlevel_ * appr_alg->size_links_per_element_;
+      unsigned int link_npy_stride = appr_alg->maxlevel_ * appr_alg->size_links_per_element_;
+
+      char* data_level0_npy = (char *) malloc(level0_npy_size);
+      char* link_list_npy = (char *) malloc(link_npy_size);
+
+      memset(data_level0_npy, 0, level0_npy_size);
+      memset(link_list_npy, 0, link_npy_size);
+
+      memcpy(data_level0_npy, appr_alg->data_level0_memory_, level0_npy_size);
+
+
+      for (size_t i = 0; i < appr_alg->cur_element_count; i++){
+        unsigned int linkListSize = appr_alg->element_levels_[i] > 0 ? appr_alg->size_links_per_element_ * appr_alg->element_levels_[i] : 0;
+        if (linkListSize){
+          memcpy(link_list_npy+(link_npy_stride * i), appr_alg->linkLists_[i], linkListSize);
+          // std::cout << linkListSize << " " << appr_alg->maxlevel_ << " " << appr_alg->element_levels_[i] << " generator: " << appr_alg->level_generator_ << std::endl;
+        }
+      }
+
+      py::capsule free_when_done_l0(data_level0_npy, [](void *f) {
+          delete[] f;
+      });
+      py::capsule free_when_done_ll(link_list_npy, [](void *f) {
+          delete[] f;
+      });
+
+      return py::make_tuple(appr_alg->offsetLevel0_,
+                            appr_alg->max_elements_,
+                            appr_alg->cur_element_count,
+                            appr_alg->size_data_per_element_,
+                            appr_alg->label_offset_,
+                            appr_alg->offsetData_,
+                            appr_alg->maxlevel_,
+                            appr_alg->enterpoint_node_,
+                            appr_alg->maxM_,
+                            appr_alg->maxM0_,
+                            appr_alg->M_,
+                            appr_alg->mult_,
+                            appr_alg->ef_construction_,
+                            appr_alg->ef_,
+                            appr_alg->has_deletions_,
+                            appr_alg->size_links_per_element_,
+                            appr_alg->label_lookup_,
+                            appr_alg->element_levels_,
+                            py::array_t<char>(
+                                    {level0_npy_size}, // shape
+                                    {sizeof(char)}, // C-style contiguous strides for double
+                                    data_level0_npy, // the data pointer
+                                    free_when_done_l0),
+                            py::array_t<char>(
+                                    {link_npy_size}, // shape
+                                    {sizeof(char)}, // C-style contiguous strides for double
+                                    link_list_npy, // the data pointer
+                                    free_when_done_ll)
+                          );
+
+    }
+
+
+    py::tuple getIndexParams() const {
+        return py::make_tuple(py::make_tuple(space_name, dim, index_inited, ep_added, normalize, num_threads_default, seed, default_ef),
+                              index_inited == true ? getAnnData() : py::make_tuple());
+
+    }
+
+
+    static Index<float> * createFromParams(const py::tuple t) {
+      py::tuple index_params=t[0].cast<py::tuple>();
+      py::tuple ann_params=t[1].cast<py::tuple>();
+
+      auto space_name_=index_params[0].cast<std::string>();
+      auto dim_=index_params[1].cast<int>();
+      auto index_inited_=index_params[2].cast<bool>();
+
+      Index<float> *new_index = new Index<float>(index_params[0].cast<std::string>(), index_params[1].cast<int>());
+
+      new_index->seed = index_params[6].cast<size_t>();
+
+
+      if (index_inited_){
+        ////                      hnswlib::HierarchicalNSW<dist_t>(l2space,            maxElements,                  M,                             efConstruction,                random_seed);
+        new_index->appr_alg = new hnswlib::HierarchicalNSW<dist_t>(new_index->l2space, ann_params[1].cast<size_t>(), ann_params[10].cast<size_t>(), ann_params[12].cast<size_t>(), new_index->seed);
+        new_index->cur_l = ann_params[2].cast<size_t>();
+      }
+
+      new_index->index_inited = index_inited_;
+      new_index->ep_added=index_params[3].cast<bool>();
+      new_index->num_threads_default=index_params[5].cast<int>();
+      new_index->default_ef=index_params[7].cast<size_t>();
+
+      if (index_inited_)
+        new_index->setAnnData(ann_params);
+
+
+      return new_index;
+    }
+
+    void setAnnData(const py::tuple t) {
+      assert_true(appr_alg->offsetLevel0_ == t[0].cast<size_t>(), "Invalid value of offsetLevel0_ ");
+      assert_true(appr_alg->max_elements_ == t[1].cast<size_t>(), "Invalid value of max_elements_ ");
+
+      appr_alg->cur_element_count = t[2].cast<size_t>();
+
+      assert_true(appr_alg->size_data_per_element_ == t[3].cast<size_t>(), "Invalid value of size_data_per_element_ ");
+      assert_true(appr_alg->label_offset_ == t[4].cast<size_t>(), "Invalid value of label_offset_ ");
+      assert_true(appr_alg->offsetData_ == t[5].cast<size_t>(), "Invalid value of offsetData_ ");
+
+      appr_alg->maxlevel_ = t[6].cast<int>();
+      appr_alg->enterpoint_node_ = t[7].cast<hnswlib::tableint>();
+
+      assert_true(appr_alg->maxM_ == t[8].cast<size_t>(), "Invalid value of maxM_ ");
+      assert_true(appr_alg->maxM0_ == t[9].cast<size_t>(), "Invalid value of maxM0_ ");
+      assert_true(appr_alg->M_ == t[10].cast<size_t>(), "Invalid value of M_ ");
+      assert_true(appr_alg->mult_ == t[11].cast<double>(), "Invalid value of mult_ ");
+      assert_true(appr_alg->ef_construction_ == t[12].cast<size_t>(), "Invalid value of ef_construction_ ");
+
+      appr_alg->ef_ = t[13].cast<size_t>();
+      appr_alg->has_deletions_=t[14].cast<bool>();
+      assert_true(appr_alg->size_links_per_element_ == t[15].cast<size_t>(), "Invalid value of size_links_per_element_ ");
+
+      auto label_lookup_dict = t[16].cast<py::dict>();
+      auto element_levels_list = t[17].cast<py::list>();
+      auto data_level0_npy = t[18].cast<py::array_t<char>>();
+      auto link_list_npy = t[19].cast<py::array_t<char>>();
+
+      for (auto el: label_lookup_dict){
+        appr_alg->label_lookup_.insert(
+          std::make_pair(
+                    el.first.cast<hnswlib::labeltype>(),
+                    el.second.cast<hnswlib::tableint>()));
+      }
+
+
+      int idx = 0;
+      for (auto el : element_levels_list){
+        appr_alg->element_levels_[idx]=el.cast<int>();
+        idx++;
+      }
+
+
+      memcpy(appr_alg->data_level0_memory_, data_level0_npy.data(), data_level0_npy.nbytes());
+
+      for (size_t i = 0; i < appr_alg->max_elements_; i++) {
+          unsigned int linkListSize = appr_alg->element_levels_[i] > 0 ? appr_alg->size_links_per_element_ * appr_alg->element_levels_[i] : 0;
+          if (linkListSize == 0) {
+              appr_alg->linkLists_[i] = nullptr;
+          } else {
+            appr_alg->linkLists_[i] = (char *) malloc(linkListSize);
+            if (appr_alg->linkLists_[i] == nullptr)
+                throw std::runtime_error("Not enough memory: loadIndex failed to allocate linklist");
+
+            memcpy(appr_alg->linkLists_[i], (link_list_npy.data()+(appr_alg->maxlevel_ * appr_alg->size_links_per_element_ * i)), linkListSize);
+
+          }
+      }
+
+
+      // TODO: use global lock for de-/serialization
+      // std::unique_lock <std::mutex> templock(global);
+      // int maxlevelcopy = maxlevel_;
+      // if (curlevel <= maxlevelcopy)
+      //     templock.unlock();
+
+    }
+
+
     py::object knnQuery_return_numpy(py::object input, size_t k = 1, int num_threads = -1) {
 
         py::array_t < dist_t, py::array::c_style | py::array::forcecast > items(input);
@@ -317,7 +546,7 @@ public:
                                 float *data= (float *) items.data(row);
 
                                 size_t start_idx = threadId * dim;
-								normalize_vector((float *) items.data(row), (norm_array.data()+start_idx));
+			                          normalize_vector((float *) items.data(row), (norm_array.data()+start_idx));
 
                                 std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result = appr_alg->searchKnn(
                                         (void *) (norm_array.data()+start_idx), k);
@@ -374,22 +603,6 @@ public:
         return appr_alg->cur_element_count;
     }
 
-    std::string space_name;
-    int dim;
-
-    bool index_inited;
-    bool ep_added;
-    bool normalize;
-    int num_threads_default;
-    hnswlib::labeltype cur_l;
-    hnswlib::HierarchicalNSW<dist_t> *appr_alg;
-    hnswlib::SpaceInterface<float> *l2space;
-
-    ~Index() {
-        delete l2space;
-        if (appr_alg)
-            delete appr_alg;
-    }
 };
 
 
@@ -397,7 +610,9 @@ public:
 PYBIND11_PLUGIN(hnswlib) {
         py::module m("hnswlib");
 
+        // py::class_<Index<float>, std::shared_ptr<Index<float> >>(m, "Index")
         py::class_<Index<float>>(m, "Index")
+        .def(py::init(&Index<float>::createFromParams), py::arg("params")) //createFromParams(const py::tuple t)
         .def(py::init<const std::string &, const int>(), py::arg("space"), py::arg("dim"))
         .def("init_index", &Index<float>::init_new_index, py::arg("max_elements"), py::arg("M")=16, py::arg("ef_construction")=200, py::arg("random_seed")=100)
         .def("knn_query", &Index<float>::knnQuery_return_numpy, py::arg("data"), py::arg("k")=1, py::arg("num_threads")=-1)
@@ -410,18 +625,23 @@ PYBIND11_PLUGIN(hnswlib) {
         .def("load_index", &Index<float>::loadIndex, py::arg("path_to_index"), py::arg("max_elements")=0)
         .def("mark_deleted", &Index<float>::markDeleted, py::arg("label"))
         .def("resize_index", &Index<float>::resizeIndex, py::arg("new_size"))
-        .def_readonly("space", &Index<float>::space_name)
+        .def_readonly("space_name", &Index<float>::space_name)
         .def_readonly("dim", &Index<float>::dim)
         .def_readwrite("num_threads", &Index<float>::num_threads_default)
         .def_property("ef",
           [](const Index<float> & index) {
-            return index.index_inited ? index.appr_alg->ef_ : 10;
+            return index.index_inited ? index.appr_alg->ef_ : index.default_ef;
           },
           [](Index<float> & index, const size_t ef_) {
-            if (index.index_inited)
+            // index.set_ef(ef_);
+            index.default_ef=ef_;
+            if (index.appr_alg)
               index.appr_alg->ef_ = ef_;
-            else
-              throw std::runtime_error("must call init_index prior to setting ef parameter");
+
+            // if (index.index_inited)
+              // index.appr_alg->ef_ = ef_;
+            // else
+              // throw std::runtime_error("must call init_index prior to setting ef parameter");
         })
         .def_property_readonly("max_elements", [](const Index<float> & index) {
             return index.index_inited ? index.appr_alg->max_elements_ : 0;
@@ -435,41 +655,126 @@ PYBIND11_PLUGIN(hnswlib) {
         .def_property_readonly("M",  [](const Index<float> & index) {
           return index.index_inited ? index.appr_alg->M_ : 0;
         })
-        .def("__getstate__", [](const Index<float> & index) { // __getstate__
-              std::stringstream output(std::stringstream::out|std::stringstream::binary);
 
+        .def(py::pickle(
+            [](const Index<float> &ind) { // __getstate__
+                /* Return a tuple that fully encodes the state of the object */
+                return ind.getIndexParams();
+            },
+            [](py::tuple t) { // __setstate__
+                if (t.size() != 2)
+                    throw std::runtime_error("Invalid state!");
+                return Index<float>::createFromParams(t);
+            }
+        ))
 
-              if (index.index_inited)
-                index.saveIndexToStream(output);
+        .def("check_integrity", [](const Index<float> & index) {
+          index.appr_alg->checkIntegrity();
+          std::cout<< index.default_ef << " " << index.appr_alg->ef_ << std::endl;
+          return index.appr_alg->ef_;
+              // return index.getIndexParams();
+              // return index.appr_alg->element_levels_;
 
-              /* Return a tuple that fully encodes the state of the object */
-              return py::make_tuple(index.space_name, index.dim,
-                                    index.index_inited, index.ep_added,
-                                    index.normalize, index.num_threads_default,
-                                    py::bytes(output.str()),
-                                    index.index_inited == false ? 10 : index.appr_alg->ef_,
-                                    index.index_inited == false ? 0  : index.appr_alg->max_elements_,
-                                    index.index_inited == false ? 0  : index.appr_alg->cur_element_count
-                                  );
+              // std::stringstream output(std::stringstream::out|std::stringstream::binary);
+              //
+              // .def("get_params", &Index<float>::getIndexParams)
+              // .def("set_params",  &Index<float>::setIndexParams,  py::arg("t"))// [](Index<float> & index, py::tuple t) {
+              //
+              // if (index.index_inited)
+              //   index.saveIndexToStream(output);
+              //
+              // /* Return a tuple that fully encodes the state of the object */
+              // return py::make_tuple(index.space_name, index.dim,
+              //                       index.index_inited, index.ep_added,
+              //                       index.normalize, index.num_threads_default,
+              //                       py::bytes(output.str()),
+              //                       index.index_inited == false ? 10 : index.appr_alg->ef_,
+              //                       index.index_inited == false ? 0  : index.appr_alg->max_elements_,
+              //                       index.index_inited == false ? 0  : index.appr_alg->cur_element_count
+              //                     );
         })
-        .def("__setstate__", [](Index<float> & index, py::tuple t) { // __setstate__
-              if (t.size() != 10)
-                  throw std::runtime_error("Invalid state!");
 
-              /* Invoke Index constructor (need to use in-place version) */
-              new (&index) Index<float>(t[0].cast<std::string>(), t[1].cast<int>());
-              index.index_inited=t[2].cast<bool>();
-              index.ep_added=t[3].cast<bool>();
-              index.normalize=t[4].cast<bool>();
-              index.num_threads_default=t[5].cast<int>();
 
-              if (index.index_inited){
-                std::stringstream input(t[6].cast<std::string>(), std::stringstream::in|std::stringstream::binary);
-                index.loadIndexFromStream(input, t[8].cast<int>()); // use max_elements from state
-                index.appr_alg->ef_=(t[7].cast<size_t>());
-              }
+                    // .def(py::pickle(
+        //     [](const Index<float> & index) { // __getstate__
+        //         /* Return a tuple that fully encodes the state of the object */
+        //         return index.getIndexParams();
+        //     },
+        //     [](Index<float> & index, py::tuple t) { // __setstate__
+        //         if (t.size() != 2)
+        //             throw std::runtime_error("Invalid state!");
+        //
+        //         /* Invoke Index constructor (need to use in-place version) */
+        //         // py::tuple index_params = t[0].cast<py::tuple>();
+        //         // Index<float> new_index(index_params[0].cast<std::string>(), index_params[1].cast<int>());
+        //         index.setIndexParams(t);
+        //         return  index;
+        //
+        //         /* Create a new C++ instance */
+        //         // Pickleable p(t[0].cast<std::string>());
+        //
+        //         /* Assign any additional state */
+        //         // p.setExtra(t[1].cast<int>());
+        //
+        //         // return p;
+        //     }
+        // ))
 
-        })
+        // .def("__getstate__", &Index<float>::getIndexParams) // __getstate__
+        // .def("__setstate__", &Index<float>::setIndexParams)  // __setstate__
+          // .def("__setstate__", [](Index<float> & index, py::tuple t) { // __setstate__
+            // py::tuple index_params = t[0].cast<py::tuple>();
+            // new (&index) Index<float>(index_params[0].cast<std::string>(), index_params[1].cast<int>());
+            // index.setIndexParams(t);
+            // return index;
+        // })
+        // .def("__getstate__", [](const Index<float> & index) { // __getstate__
+        //       return index.getIndexParams();
+        //
+        //       // std::stringstream output(std::stringstream::out|std::stringstream::binary);
+        //       //
+        //       // .def("get_params", &Index<float>::getIndexParams)
+        //       // .def("set_params",  &Index<float>::setIndexParams,  py::arg("t"))// [](Index<float> & index, py::tuple t) {
+        //       //
+        //       // if (index.index_inited)
+        //       //   index.saveIndexToStream(output);
+        //       //
+        //       // /* Return a tuple that fully encodes the state of the object */
+        //       // return py::make_tuple(index.space_name, index.dim,
+        //       //                       index.index_inited, index.ep_added,
+        //       //                       index.normalize, index.num_threads_default,
+        //       //                       py::bytes(output.str()),
+        //       //                       index.index_inited == false ? 10 : index.appr_alg->ef_,
+        //       //                       index.index_inited == false ? 0  : index.appr_alg->max_elements_,
+        //       //                       index.index_inited == false ? 0  : index.appr_alg->cur_element_count
+        //       //                     );
+        // })
+        // .def("set_state", [](Index<float> & index, py::tuple t) { // __setstate__
+        //   index.setIndexParams(t);
+        // })
+        //
+        // .def("__setstate__", [](Index<float> & index, py::tuple t) { // __setstate__
+        //       // delete &index;
+        //       /* Invoke Index constructor (need to use in-place version) */
+        //       // py::tuple index_params = t[0].cast<py::tuple>();
+        //       // new (&index) Index<float>(index_params[0].cast<std::string>(), index_params[1].cast<int>());
+        //       index.setIndexParams(t);
+        //       // if (t.size() != 10)
+        //       //     throw std::runtime_error("Invalid state!");
+        //       //
+        //
+        //       // index.index_inited=t[2].cast<bool>();
+        //       // index.ep_added=t[3].cast<bool>();
+        //       // index.normalize=t[4].cast<bool>();
+        //       // index.num_threads_default=t[5].cast<int>();
+        //       //
+        //       // if (index.index_inited){
+        //       //   std::stringstream input(t[6].cast<std::string>(), std::stringstream::in|std::stringstream::binary);
+        //       //   index.loadIndexFromStream(input, t[8].cast<int>()); // use max_elements from state
+        //       //   index.appr_alg->ef_=(t[7].cast<size_t>());
+        //       // }
+        //
+        // })
         .def("__repr__", [](const Index<float> &a) {
             return "<hnswlib.Index(space='" + a.space_name + "', dim="+std::to_string(a.dim)+")>";
         });

--- a/python_bindings/tests/bindings_test_pickle.py
+++ b/python_bindings/tests/bindings_test_pickle.py
@@ -19,9 +19,8 @@ def brute_force_distances(metric, items, query_items, k):
         for jj in range(query_items.shape[0]):
             dists[jj,ii]=get_dist(metric, items[ii, :], query_items[jj, :])
 
-    labels = np.argsort(dists, axis=1)
-    dists = np.sort(dists, axis=1)
-
+    labels = np.argsort(dists, axis=1) # equivalent, but faster: np.argpartition(dists, range(k), axis=1)
+    dists = np.sort(dists, axis=1)     # equivalent, but faster: np.partition(dists, range(k), axis=1)
 
     return labels[:,:k], dists[:,:k]
 
@@ -141,19 +140,14 @@ class PickleUnitTests(unittest.TestCase):
                                  ### number of value pairs that are allowed to be different in d1 and d2
                                  ### i.e., number of values that are (d1-d2)**2>1e-3
 
-    def testInnerProductSpace(self):
+    def test_inner_product_space(self):
         test_space_main(self, 'ip', 48)
 
-    def testL2Space(self):
+    def test_l2_space(self):
         test_space_main(self, 'l2', 153)
 
-    def testCosineSpace(self):
+    def test_cosine_space(self):
         test_space_main(self, 'cosine', 512)
-
-        #
-        # for space,dim in [('ip', 48), ('l2', 152), ('cosine', 512)]:
-        #     test_space_main
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/python_bindings/tests/bindings_test_pickle.py
+++ b/python_bindings/tests/bindings_test_pickle.py
@@ -1,0 +1,144 @@
+import unittest
+
+import numpy as np
+
+
+def get_dist(metric, pt1, pt2):
+    if metric == 'l2':
+        return np.sum((pt1-pt2)**2)
+    elif metric == 'ip':
+        return 1. - np.sum(np.multiply(pt1,pt2))
+    elif metric == 'cosine':
+        return 1. - np.sum(np.multiply(pt1,pt2)) / (np.sum(pt1**2) * np.sum(pt2**2))**.5
+
+def brute_force_distances(metric, items, query_items, k):
+    dists=np.zeros((query_items.shape[0], items.shape[0]))
+    for ii in range(items.shape[0]):
+        for jj in range(query_items.shape[0]):
+            dists[jj,ii]=get_dist(metric, items[ii, :], query_items[jj, :])
+
+    labels = np.argsort(dists, axis=1)
+    dists = np.sort(dists, axis=1)
+
+
+    return labels[:,:k], dists[:,:k]
+
+
+class PickleSelfTestCase(unittest.TestCase):
+
+    def check_ann_results(self, metric, items, query_items, k, ann_l, ann_d, err_thresh=0, total_thresh=0, dists_thresh=0):
+        brute_l, brute_d = brute_force_distances(metric, items, query_items, k)
+        err_total = 0
+        for jj in range(query_items.shape[0]):
+            err = np.sum(np.isin(brute_l[jj, :], ann_l[jj, :], invert=True))
+            if err > 0:
+                print(f"Warning: {err} labels are missing from ann results (k={k}, err_thresh={err_thresh})")
+
+            if err > err_thresh:
+                err_total += 1
+                
+        self.assertLessEqual( err_total, total_thresh, f"Error: knn_query returned incorrect labels for {err_total} items (k={k})")
+
+        wrong_dists=np.sum(((brute_d- ann_d)**2.)>1e-3)
+        if wrong_dists > 0:
+            dists_count=brute_d.shape[0]*brute_d.shape[1]
+            print(f"Warning: {wrong_dists} ann distance values are different from brute-force values (total # of values={dists_count}, dists_thresh={dists_thresh})")
+            
+        self.assertLessEqual( wrong_dists, dists_thresh, msg=f"Error: {wrong_dists} ann distance values are different from brute-force values")
+
+    def testPickle(self):
+        import hnswlib
+        import pickle
+
+        ef_construction = 725
+        M = 64
+        ef = 725
+
+        num_elements = 5000
+        num_test_elements = 100
+
+        num_threads = 4
+        k = 15
+        
+        label_err_thresh=5  ### max number of missing labels allowed per test item
+        item_err_thresh=5   ### max number of items allowed with incorrect labels 
+
+        dists_err_thresh=50 ### for two matrices, d1 and d2, dists_err_thresh controls max 
+                            ### number of value pairs that are allowed to be different in d1 and d2
+                            ### i.e., number of values that are (d1-d2)**2>1e-3
+
+        for space,dim in [('ip', 48), ('l2', 152), ('cosine', 512)]:
+
+            # Generating sample data
+            data = np.float32(np.random.random((num_elements, dim)))
+            test_data = np.float32(np.random.random((num_test_elements, dim)))
+
+            # Declaring index
+            p = hnswlib.Index(space=space, dim=dim)  # possible options are l2, cosine or ip
+            print(f"Running pickle tests for {p}")
+
+            p.num_threads=num_threads  # by default using all available cores
+
+            p0=pickle.loads(pickle.dumps(p)) ### pickle un-initialized Index
+            p.init_index(max_elements = num_elements, ef_construction = ef_construction, M = M)
+            p0.init_index(max_elements = num_elements, ef_construction = ef_construction, M = M)
+
+            p.ef=ef  ### Note: ef parameter can be set only after calling p.init_index,
+            p0.ef=ef ###       so we have to set p0.ef 
+
+            p1=pickle.loads(pickle.dumps(p)) ### pickle Index before adding items
+
+            ### add items to ann index p,p0,p1 
+            p.add_items(data)  
+            p1.add_items(data) 
+            p0.add_items(data)
+            
+            p2=pickle.loads(pickle.dumps(p)) ### pickle Index before adding items
+
+            self.assertTrue(np.allclose(p.get_items(), p0.get_items()), "items for p and p0 must be same")
+            self.assertTrue(np.allclose(p0.get_items(), p1.get_items()), "items for p0 and p1 must be same")
+            self.assertTrue(np.allclose(p1.get_items(), p2.get_items()), "items for p1 and p2 must be same")
+
+            ### Test if returned distances are same
+            l, d   = p.knn_query(test_data, k=k)
+            l0, d0 = p0.knn_query(test_data, k=k)
+            l1, d1 = p1.knn_query(test_data, k=k)
+            l2, d2 = p2.knn_query(test_data, k=k)
+
+            self.assertLessEqual(np.sum(((d-d0)**2.)>1e-3), dists_err_thresh, msg=f"knn distances returned by p and p0 must match")
+            self.assertLessEqual(np.sum(((d0-d1)**2.)>1e-3), dists_err_thresh, msg=f"knn distances returned by p0 and p1 must match")
+            self.assertLessEqual(np.sum(((d1-d2)**2.)>1e-3), dists_err_thresh, msg=f"knn distances returned by p1 and p2 must match")
+
+            ### check if ann results match brute-force search
+            ###   allow for 2 labels to be missing from ann results
+            self.check_ann_results(space, data, test_data, k, l, d, 
+                                   err_thresh = label_err_thresh, 
+                                   total_thresh = item_err_thresh, 
+                                   dists_thresh = dists_err_thresh)
+            
+            self.check_ann_results(space, data, test_data, k, l2, d2, 
+                                   err_thresh=label_err_thresh, 
+                                   total_thresh=item_err_thresh, 
+                                   dists_thresh=dists_err_thresh)
+
+            ### Check ef parameter value
+            self.assertEqual(p.ef, ef, "incorrect value of p.ef")
+            self.assertEqual(p0.ef, ef, "incorrect value of p0.ef")
+            self.assertEqual(p2.ef, ef, "incorrect value of p2.ef")
+            self.assertEqual(p1.ef, ef, "incorrect value of p1.ef")
+
+            ### Check M parameter value
+            self.assertEqual(p.M, M, "incorrect value of p.M")
+            self.assertEqual(p0.M, M, "incorrect value of p0.M")
+            self.assertEqual(p1.M, M, "incorrect value of p1.M")
+            self.assertEqual(p2.M, M, "incorrect value of p2.M")
+
+            ### Check ef_construction parameter value
+            self.assertEqual(p.ef_construction, ef_construction, "incorrect value of p.ef_construction")
+            self.assertEqual(p0.ef_construction, ef_construction, "incorrect value of p0.ef_construction")
+            self.assertEqual(p1.ef_construction, ef_construction, "incorrect value of p1.ef_construction")
+            self.assertEqual(p2.ef_construction, ef_construction, "incorrect value of p2.ef_construction")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python_bindings/tests/bindings_test_pickle.py
+++ b/python_bindings/tests/bindings_test_pickle.py
@@ -1,6 +1,8 @@
 import unittest
 
 import numpy as np
+import hnswlib
+import pickle
 
 
 def get_dist(metric, pt1, pt2):
@@ -24,120 +26,133 @@ def brute_force_distances(metric, items, query_items, k):
     return labels[:,:k], dists[:,:k]
 
 
-class PickleSelfTestCase(unittest.TestCase):
+def check_ann_results(self, metric, items, query_items, k, ann_l, ann_d, err_thresh=0, total_thresh=0, dists_thresh=0):
+    brute_l, brute_d = brute_force_distances(metric, items, query_items, k)
+    err_total = 0
+    for jj in range(query_items.shape[0]):
+        err = np.sum(np.isin(brute_l[jj, :], ann_l[jj, :], invert=True))
+        if err > 0:
+            print(f"Warning: {err} labels are missing from ann results (k={k}, err_thresh={err_thresh})")
 
-    def check_ann_results(self, metric, items, query_items, k, ann_l, ann_d, err_thresh=0, total_thresh=0, dists_thresh=0):
-        brute_l, brute_d = brute_force_distances(metric, items, query_items, k)
-        err_total = 0
-        for jj in range(query_items.shape[0]):
-            err = np.sum(np.isin(brute_l[jj, :], ann_l[jj, :], invert=True))
-            if err > 0:
-                print(f"Warning: {err} labels are missing from ann results (k={k}, err_thresh={err_thresh})")
+        if err > err_thresh:
+            err_total += 1
 
-            if err > err_thresh:
-                err_total += 1
-                
-        self.assertLessEqual( err_total, total_thresh, f"Error: knn_query returned incorrect labels for {err_total} items (k={k})")
+    self.assertLessEqual( err_total, total_thresh, f"Error: knn_query returned incorrect labels for {err_total} items (k={k})")
 
-        wrong_dists=np.sum(((brute_d- ann_d)**2.)>1e-3)
-        if wrong_dists > 0:
-            dists_count=brute_d.shape[0]*brute_d.shape[1]
-            print(f"Warning: {wrong_dists} ann distance values are different from brute-force values (total # of values={dists_count}, dists_thresh={dists_thresh})")
-            
-        self.assertLessEqual( wrong_dists, dists_thresh, msg=f"Error: {wrong_dists} ann distance values are different from brute-force values")
+    wrong_dists=np.sum(((brute_d- ann_d)**2.)>1e-3)
+    if wrong_dists > 0:
+        dists_count=brute_d.shape[0]*brute_d.shape[1]
+        print(f"Warning: {wrong_dists} ann distance values are different from brute-force values (total # of values={dists_count}, dists_thresh={dists_thresh})")
 
-    def testPickle(self):
-        import hnswlib
-        import pickle
+    self.assertLessEqual( wrong_dists, dists_thresh, msg=f"Error: {wrong_dists} ann distance values are different from brute-force values")
 
-        ef_construction = 725
-        M = 64
-        ef = 725
+def test_space_main(self, space, dim):
 
-        num_elements = 5000
-        num_test_elements = 200
+    # Generating sample data
+    data = np.float32(np.random.random((self.num_elements, dim)))
+    test_data = np.float32(np.random.random((self.num_test_elements, dim)))
 
-        num_threads = 4
-        k = 15
-        
-        label_err_thresh=5  ### max number of missing labels allowed per test item
-        item_err_thresh=5   ### max number of items allowed with incorrect labels 
+    # Declaring index
+    p = hnswlib.Index(space=space, dim=dim)  # possible options are l2, cosine or ip
+    print(f"Running pickle tests for {p}")
 
-        dists_err_thresh=50 ### for two matrices, d1 and d2, dists_err_thresh controls max 
-                            ### number of value pairs that are allowed to be different in d1 and d2
-                            ### i.e., number of values that are (d1-d2)**2>1e-3
+    p.num_threads=self.num_threads  # by default using all available cores
 
-        for space,dim in [('ip', 48), ('l2', 152), ('cosine', 512)]:
+    p0=pickle.loads(pickle.dumps(p)) ### pickle un-initialized Index
+    p.init_index(max_elements = self.num_elements, ef_construction = self.ef_construction, M = self.M)
+    p0.init_index(max_elements = self.num_elements, ef_construction = self.ef_construction, M = self.M)
 
-            # Generating sample data
-            data = np.float32(np.random.random((num_elements, dim)))
-            test_data = np.float32(np.random.random((num_test_elements, dim)))
+    p.ef=self.ef
+    p0.ef=self.ef
 
-            # Declaring index
-            p = hnswlib.Index(space=space, dim=dim)  # possible options are l2, cosine or ip
-            print(f"Running pickle tests for {p}")
+    p1=pickle.loads(pickle.dumps(p)) ### pickle Index before adding items
 
-            p.num_threads=num_threads  # by default using all available cores
+    ### add items to ann index p,p0,p1
+    p.add_items(data)
+    p1.add_items(data)
+    p0.add_items(data)
 
-            p0=pickle.loads(pickle.dumps(p)) ### pickle un-initialized Index
-            p.init_index(max_elements = num_elements, ef_construction = ef_construction, M = M)
-            p0.init_index(max_elements = num_elements, ef_construction = ef_construction, M = M)
+    p2=pickle.loads(pickle.dumps(p)) ### pickle Index before adding items
 
-            p.ef=ef  ### Note: ef parameter can be set only after calling p.init_index,
-            p0.ef=ef ###       so we have to set p0.ef 
+    self.assertTrue(np.allclose(p.get_items(), p0.get_items()), "items for p and p0 must be same")
+    self.assertTrue(np.allclose(p0.get_items(), p1.get_items()), "items for p0 and p1 must be same")
+    self.assertTrue(np.allclose(p1.get_items(), p2.get_items()), "items for p1 and p2 must be same")
 
-            p1=pickle.loads(pickle.dumps(p)) ### pickle Index before adding items
+    ### Test if returned distances are same
+    l, d   = p.knn_query(test_data, k=self.k)
+    l0, d0 = p0.knn_query(test_data, k=self.k)
+    l1, d1 = p1.knn_query(test_data, k=self.k)
+    l2, d2 = p2.knn_query(test_data, k=self.k)
 
-            ### add items to ann index p,p0,p1 
-            p.add_items(data)  
-            p1.add_items(data) 
-            p0.add_items(data)
-            
-            p2=pickle.loads(pickle.dumps(p)) ### pickle Index before adding items
+    self.assertLessEqual(np.sum(((d-d0)**2.)>1e-3), self.dists_err_thresh, msg=f"knn distances returned by p and p0 must match")
+    self.assertLessEqual(np.sum(((d0-d1)**2.)>1e-3), self.dists_err_thresh, msg=f"knn distances returned by p0 and p1 must match")
+    self.assertLessEqual(np.sum(((d1-d2)**2.)>1e-3), self.dists_err_thresh, msg=f"knn distances returned by p1 and p2 must match")
 
-            self.assertTrue(np.allclose(p.get_items(), p0.get_items()), "items for p and p0 must be same")
-            self.assertTrue(np.allclose(p0.get_items(), p1.get_items()), "items for p0 and p1 must be same")
-            self.assertTrue(np.allclose(p1.get_items(), p2.get_items()), "items for p1 and p2 must be same")
+    ### check if ann results match brute-force search
+    ###   allow for 2 labels to be missing from ann results
+    check_ann_results(self, space, data, test_data, self.k, l, d,
+                           err_thresh = self.label_err_thresh,
+                           total_thresh = self.item_err_thresh,
+                           dists_thresh = self.dists_err_thresh)
 
-            ### Test if returned distances are same
-            l, d   = p.knn_query(test_data, k=k)
-            l0, d0 = p0.knn_query(test_data, k=k)
-            l1, d1 = p1.knn_query(test_data, k=k)
-            l2, d2 = p2.knn_query(test_data, k=k)
+    check_ann_results(self, space, data, test_data, self.k, l2, d2,
+                           err_thresh=self.label_err_thresh,
+                           total_thresh=self.item_err_thresh,
+                           dists_thresh=self.dists_err_thresh)
 
-            self.assertLessEqual(np.sum(((d-d0)**2.)>1e-3), dists_err_thresh, msg=f"knn distances returned by p and p0 must match")
-            self.assertLessEqual(np.sum(((d0-d1)**2.)>1e-3), dists_err_thresh, msg=f"knn distances returned by p0 and p1 must match")
-            self.assertLessEqual(np.sum(((d1-d2)**2.)>1e-3), dists_err_thresh, msg=f"knn distances returned by p1 and p2 must match")
+    ### Check ef parameter value
+    self.assertEqual(p.ef, self.ef, "incorrect value of p.ef")
+    self.assertEqual(p0.ef, self.ef, "incorrect value of p0.ef")
+    self.assertEqual(p2.ef, self.ef, "incorrect value of p2.ef")
+    self.assertEqual(p1.ef, self.ef, "incorrect value of p1.ef")
 
-            ### check if ann results match brute-force search
-            ###   allow for 2 labels to be missing from ann results
-            self.check_ann_results(space, data, test_data, k, l, d, 
-                                   err_thresh = label_err_thresh, 
-                                   total_thresh = item_err_thresh, 
-                                   dists_thresh = dists_err_thresh)
-            
-            self.check_ann_results(space, data, test_data, k, l2, d2, 
-                                   err_thresh=label_err_thresh, 
-                                   total_thresh=item_err_thresh, 
-                                   dists_thresh=dists_err_thresh)
+    ### Check M parameter value
+    self.assertEqual(p.M, self.M, "incorrect value of p.M")
+    self.assertEqual(p0.M, self.M, "incorrect value of p0.M")
+    self.assertEqual(p1.M, self.M, "incorrect value of p1.M")
+    self.assertEqual(p2.M, self.M, "incorrect value of p2.M")
 
-            ### Check ef parameter value
-            self.assertEqual(p.ef, ef, "incorrect value of p.ef")
-            self.assertEqual(p0.ef, ef, "incorrect value of p0.ef")
-            self.assertEqual(p2.ef, ef, "incorrect value of p2.ef")
-            self.assertEqual(p1.ef, ef, "incorrect value of p1.ef")
+    ### Check ef_construction parameter value
+    self.assertEqual(p.ef_construction, self.ef_construction, "incorrect value of p.ef_construction")
+    self.assertEqual(p0.ef_construction, self.ef_construction, "incorrect value of p0.ef_construction")
+    self.assertEqual(p1.ef_construction, self.ef_construction, "incorrect value of p1.ef_construction")
+    self.assertEqual(p2.ef_construction, self.ef_construction, "incorrect value of p2.ef_construction")
 
-            ### Check M parameter value
-            self.assertEqual(p.M, M, "incorrect value of p.M")
-            self.assertEqual(p0.M, M, "incorrect value of p0.M")
-            self.assertEqual(p1.M, M, "incorrect value of p1.M")
-            self.assertEqual(p2.M, M, "incorrect value of p2.M")
 
-            ### Check ef_construction parameter value
-            self.assertEqual(p.ef_construction, ef_construction, "incorrect value of p.ef_construction")
-            self.assertEqual(p0.ef_construction, ef_construction, "incorrect value of p0.ef_construction")
-            self.assertEqual(p1.ef_construction, ef_construction, "incorrect value of p1.ef_construction")
-            self.assertEqual(p2.ef_construction, ef_construction, "incorrect value of p2.ef_construction")
+
+class PickleUnitTests(unittest.TestCase):
+
+    def setUp(self):
+
+        self.ef_construction = 725
+        self.M = 64
+        self.ef = 725
+
+        self.num_elements = 5000
+        self.num_test_elements = 200
+
+        self.num_threads = 4
+        self.k = 25
+
+        self.label_err_thresh=5  ### max number of missing labels allowed per test item
+        self.item_err_thresh=5   ### max number of items allowed with incorrect labels
+
+        self.dists_err_thresh=50 ### for two matrices, d1 and d2, dists_err_thresh controls max
+                                 ### number of value pairs that are allowed to be different in d1 and d2
+                                 ### i.e., number of values that are (d1-d2)**2>1e-3
+
+    def testInnerProductSpace(self):
+        test_space_main(self, 'ip', 48)
+
+    def testL2Space(self):
+        test_space_main(self, 'l2', 153)
+
+    def testCosineSpace(self):
+        test_space_main(self, 'cosine', 512)
+
+        #
+        # for space,dim in [('ip', 48), ('l2', 152), ('cosine', 512)]:
+        #     test_space_main
 
 
 if __name__ == "__main__":

--- a/python_bindings/tests/bindings_test_pickle.py
+++ b/python_bindings/tests/bindings_test_pickle.py
@@ -55,7 +55,7 @@ class PickleSelfTestCase(unittest.TestCase):
         ef = 725
 
         num_elements = 5000
-        num_test_elements = 100
+        num_test_elements = 200
 
         num_threads = 4
         k = 15


### PR DESCRIPTION
## Changes 

* [Index](https://github.com/dbespalov/hnswlib/blob/python_bindings_pickle_io/python_bindings/bindings.cpp) class
  * Static factory methods `createFromIndex` and `createFromParams` for Index construction from another Index object or Index parameter tuple, respectively
  * Method `getIndexParams` serializes Index object. Returns a tuple with Index parameters.
  * Method `getAnnData` returns a tuple with hnsw-specific parameters. Copy of `appr_alg->data_level0_memory_` and `appr_alg->linkLists_` are returned as `py::array_t<char>` objects to avoid additional copying from python side

* Python bindings for [Index](https://github.com/dbespalov/hnswlib/blob/python_bindings_pickle_io/python_bindings/bindings.cpp) class 
  * Index serialization is implemented with `py::pickle` definition from pybind11
  * Bind `Index.__init__` to static factory methods `createFromIndex` and `createFromParams`
  * Expose parameters of the hnsw index as read-only properties in python:
    * `space_name, dim, max_elements, element_count, ef_construction, M, num_threads, ef`
  * And, two properties that support read and write:
    * `ef, num_threads`

* Updated API documentation and the first python example in [README.md](https://github.com/dbespalov/hnswlib/blob/python_bindings_pickle_io/README.md)

* New test in [python_bindings/tests/bindings_test_pickle.py](https://github.com/dbespalov/hnswlib/blob/python_bindings_pickle_io/python_bindings/tests/bindings_test_pickle.py).
  * Verifies that results of knn_query match results from copies of the same index. `Index` objects are copied using round-trip pickling.
  * Verify that knn_query gives recall of (almost) 100% for `k=25` using three spaces. Brute-force search is used to return ground-truth labels for the randomly generated items.
  * Create separate test for each space 
  * Sample test output:
```bash
> python3 -m unittest  tests/bindings_test_pickle.py -k Inner
Running pickle tests for <hnswlib.Index(space='ip', dim=48)>
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
 ... 
Warning: 16 ann distance values are different from brute-force values (total # of values=5000, dists_thresh=50)

.
----------------------------------------------------------------------
Ran 1 test in 19.057s

OK
```

