### PR TITLE
Throw an exception if passed an unrecognized space_name.

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -97,6 +97,8 @@ public:
     else if(space_name=="cosine") {
       l2space = new hnswlib::InnerProductSpace(dim);
       normalize=true;
+    } else {
+      throw new std::runtime_error("Space name must be one of l2, ip, or cosine.");
     }
     appr_alg = NULL;
     ep_added = true;


### PR DESCRIPTION
Currently, `hnswlib` will segfault if called from Python with an unrecognized `space_name`, as `l2space` is left undefined. This PR proposes a fix for that by throwing an exception instead.