### PR TITLE
Fix sign-compare warnings

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -91,13 +91,13 @@ namespace hnswlib {
         searchKnn(const void *query_data, size_t k) const {
             std::priority_queue<std::pair<dist_t, labeltype >> topResults;
             if (cur_element_count == 0) return topResults;
-            for (int i = 0; i < k; i++) {
+            for (size_t i = 0; i < k; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 topResults.push(std::pair<dist_t, labeltype>(dist, *((labeltype *) (data_ + size_per_element_ * i +
                                                                                     data_size_))));
             }
             dist_t lastdist = topResults.top().first;
-            for (int i = k; i < cur_element_count; i++) {
+            for (size_t i = k; i < cur_element_count; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 if (dist <= lastdist) {
                     topResults.push(std::pair<dist_t, labeltype>(dist, *((labeltype *) (data_ + size_per_element_ * i +

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -757,7 +757,7 @@ namespace hnswlib {
             size_t dim = *((size_t *) dist_func_param_);
             std::vector<data_t> data;
             data_t* data_ptr = (data_t*) data_ptrv;
-            for (int i = 0; i < dim; i++) {
+            for (size_t i = 0; i < dim; i++) {
                 data.push_back(*data_ptr);
                 data_ptr += 1;
             }


### PR DESCRIPTION
I have encountered sign-compare warnings and fixed them:

```sh
$ g++ -std=c++14 -Wsign-compare examples/searchKnnCloserFirst_test.cpp
In file included from examples/searchKnnCloserFirst_test.cpp:6:
In file included from examples/../hnswlib/hnswlib.h:108:
examples/../hnswlib/hnswalg.h:760:31: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
            for (int i = 0; i < dim; i++) {
                            ~ ^ ~~~
In file included from examples/searchKnnCloserFirst_test.cpp:6:
In file included from examples/../hnswlib/hnswlib.h:107:
examples/../hnswlib/bruteforce.h:94:31: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
            for (int i = 0; i < k; i++) {
                            ~ ^ ~
examples/../hnswlib/bruteforce.h:18:9: note: in instantiation of member function 'hnswlib::BruteforceSearch<float>::searchKnn' requested here
        BruteforceSearch(SpaceInterface <dist_t> *s, size_t maxElements) {
        ^
examples/searchKnnCloserFirst_test.cpp:40:58: note: in instantiation of member function 'hnswlib::BruteforceSearch<float>::BruteforceSearch' requested here
    hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float>(&space, 2 * n);
                                                         ^
In file included from examples/searchKnnCloserFirst_test.cpp:6:
In file included from examples/../hnswlib/hnswlib.h:107:
examples/../hnswlib/bruteforce.h:100:31: warning: comparison of integers of different signs: 'int' and 'const size_t' (aka 'const unsigned long') [-Wsign-compare]
            for (int i = k; i < cur_element_count; i++) {
                            ~ ^ ~~~~~~~~~~~~~~~~~
3 warnings generated.
```