### PR TITLE
Expose CMake target for use via FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,27 @@
-cmake_minimum_required (VERSION 2.6)
-project (hnsw_lib)
+cmake_minimum_required (VERSION 3.14)
+project(hnsw_lib
+    LANGUAGES CXX)
 
-include_directories("${PROJECT_BINARY_DIR}")
+add_library(hnswlib INTERFACE)
+target_include_directories(hnswlib INTERFACE .) 
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(CMAKE_CXX_STANDARD 11)
 
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      SET( CMAKE_CXX_FLAGS  "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -ftree-vectorize")
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -march=native -fpic -w -fopenmp -ftree-vectorize -ftree-vectorizer-verbose=0" )
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -w -fopenmp -ftree-vectorize" )
+    endif()
 
-set(SOURCE_EXE main.cpp)           
+    add_executable(test_updates examples/updates_test.cpp)
+    target_link_libraries(test_updates hnswlib)
 
-set(SOURCE_LIB sift_1b.cpp)
+    add_executable(searchKnnCloserFirst_test examples/searchKnnCloserFirst_test.cpp)
+    target_link_libraries(searchKnnCloserFirst_test hnswlib)
 
-add_library(sift_test STATIC ${SOURCE_LIB})
-
-
-add_executable(main ${SOURCE_EXE})
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  SET( CMAKE_CXX_FLAGS  "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -ftree-vectorize")
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -w -fopenmp -ftree-vectorize -ftree-vectorizer-verbose=0" )
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -w -fopenmp -ftree-vectorize" )
+    add_executable(main main.cpp sift_1b.cpp)
+    target_link_libraries(main hnswlib)
 endif()
-
-add_executable(test_updates examples/updates_test.cpp)
-
-add_executable(searchKnnCloserFirst_test examples/searchKnnCloserFirst_test.cpp)
-
-target_link_libraries(main sift_test) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14)
+cmake_minimum_required (VERSION 2.6)
 project(hnsw_lib
     LANGUAGES CXX)
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -744,7 +744,7 @@ namespace hnswlib {
         }
 
         template<typename data_t>
-        std::vector<data_t> getDataByLabel(labeltype label)
+        std::vector<data_t> getDataByLabel(labeltype label) const
         {
             tableint label_c;
             auto search = label_lookup_.find(label);

--- a/hnswlib/visited_list_pool.h
+++ b/hnswlib/visited_list_pool.h
@@ -2,6 +2,7 @@
 
 #include <mutex>
 #include <string.h>
+#include <deque>
 
 namespace hnswlib {
     typedef unsigned short int vl_type;


### PR DESCRIPTION
This allows other CMake projects to include HNSW via CMake's `FetchContent` approach, e.g.,

```
FetchContent_Declare(
  hnswlib
  GIT_REPOSITORY https://github.com/nmslib/hnswlib
  GIT_TAG master
)

FetchContent_MakeAvailable(hnswlib)

target_link_libraries(my_lib PUBLIC hnswlib)
```

A real-world example is available at https://github.com/LTLA/knncolle/blob/master/extern/CMakeLists.txt.

I moved the test building directives into a conditional that only triggers when actually building Hnswlib. This ensures that downstream projects are not saddled with the need to build the tests when all they want are the headers.

I also took the liberty of making `getDataByLabel` `const`, to indicate that it could be safely used in parallel frameworks that do not expect modifications to the index upon query; and I added a missing header for `<deque>`.