### PR TITLE
Insufficient results may occur(has marked_deleted node)

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -182,7 +182,7 @@ namespace hnswlib {
 
             while (!candidateSet.empty()) {
                 std::pair<dist_t, tableint> curr_el_pair = candidateSet.top();
-                if ((-curr_el_pair.first) > lowerBound and top_candidates.size() == ef_construction_) {
+                if ((-curr_el_pair.first) > lowerBound && top_candidates.size() == ef_construction_) {
                     break;
                 }
                 candidateSet.pop();
@@ -271,7 +271,7 @@ namespace hnswlib {
 
                 std::pair<dist_t, tableint> current_node_pair = candidate_set.top();
 
-                if ((-current_node_pair.first) > lowerBound and top_candidates.size() == ef) {
+                if ((-current_node_pair.first) > lowerBound && top_candidates.size() == ef) {
                     break;
                 }
                 candidate_set.pop();

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -271,7 +271,7 @@ namespace hnswlib {
 
                 std::pair<dist_t, tableint> current_node_pair = candidate_set.top();
 
-                if ((-current_node_pair.first) > lowerBound && top_candidates.size() == ef) {
+                if ((-current_node_pair.first) > lowerBound && (top_candidates.size() == ef || has_deletions == false)) {
                     break;
                 }
                 candidate_set.pop();

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -182,7 +182,7 @@ namespace hnswlib {
 
             while (!candidateSet.empty()) {
                 std::pair<dist_t, tableint> curr_el_pair = candidateSet.top();
-                if ((-curr_el_pair.first) > lowerBound) {
+                if ((-curr_el_pair.first) > lowerBound and top_candidates.size() == ef_construction_) {
                     break;
                 }
                 candidateSet.pop();
@@ -271,7 +271,7 @@ namespace hnswlib {
 
                 std::pair<dist_t, tableint> current_node_pair = candidate_set.top();
 
-                if ((-current_node_pair.first) > lowerBound) {
+                if ((-current_node_pair.first) > lowerBound and top_candidates.size() == ef) {
                     break;
                 }
                 candidate_set.pop();


### PR DESCRIPTION
In the case of marked_deleted, Insufficient results may occur(edge case)

#### problem
* If top_candidate is insufficient, additional search is performed for the Candidate_set.

* When the experiment was conducted with 50% of deletion masking, about 3 out of 10,000 cases had insufficient results. (eg. 100 nodes have been requested, but 1 is returned.)

* If all of the neighbors of the entry point are deleted nodes, the candidate_set contains data to be searched, but the lower_bound is not modified by the top_candidate, so there is a problem of stopping without further searching.


[Examples of cases that occurrence]

<details>

e.g Entry point is a normal node. 
If all neighboring entries at the entry point are masked deletion nodes, the Candidate_set tour ends at the lower_bound.
<img width="829" alt="image1" src="https://user-images.githubusercontent.com/19380703/138679191-703f6908-009d-4639-85ea-d33898703566.png">


e.g If there were no delete masked nodes, the Candidate_set would have been additionally toured.
<img width="915" alt="image2" src="https://user-images.githubusercontent.com/19380703/138679207-e021aa22-142e-4687-bfb8-181d8c767166.png">


</details>

#### solve
* If the top_candidate is insufficient, the problem can be supplemented by allowing the cadidate_set to search further when there is data.

https://github.com/nmslib/hnswlib/blob/ac43973f1f27b809d6ce181130d9aa4f95050057/hnswlib/hnswalg.h#L272-L276
```cpp
                std::pair<dist_t, tableint> current_node_pair = candidate_set.top();

                // TO-BE: I suggest
                if ((-current_node_pair.first) > lowerBound and top_candidates.size() == ef) {  
                //if ((-current_node_pair.first) > lowerBound) { // AS-IS 
                    break;
                }
```

thanks :)


