### PR TITLE
AVX runtime check

### DIFF
--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -84,7 +84,7 @@ bool AVXCapable() {
         uint64_t xcrFeatureMask = xgetbv(_XCR_XFEATURE_ENABLED_MASK);
         avxSupported = (xcrFeatureMask & 0x6) == 0x6;
     }
-    return avxSupported;
+    return HW_AVX && avxSupported;
 }
 
 bool AVX512Capable() {
@@ -96,8 +96,8 @@ bool AVX512Capable() {
     cpuid(cpuInfo, 0, 0);
     int nIds = cpuInfo[0];
 
-    bool HW_AVX512F = false;    //  AVX512 Foundation
-    if (nIds >= 0x00000007) {
+    bool HW_AVX512F = false;
+    if (nIds >= 0x00000007) { //  AVX512 Foundation
         cpuid(cpuInfo, 0x00000007, 0);
         HW_AVX512F = (cpuInfo[1] & ((int)1 << 16)) != 0;
     }
@@ -108,13 +108,12 @@ bool AVX512Capable() {
     bool osUsesXSAVE_XRSTORE = (cpuInfo[2] & (1 << 27)) != 0;
     bool cpuAVXSuport = (cpuInfo[2] & (1 << 28)) != 0;
 
-    bool avxSupported = false;
     bool avx512Supported = false;
     if (osUsesXSAVE_XRSTORE && cpuAVXSuport) {
         uint64_t xcrFeatureMask = xgetbv(_XCR_XFEATURE_ENABLED_MASK);
         avx512Supported = (xcrFeatureMask & 0xe6) == 0xe6;
     }
-    return avx512Supported;
+    return HW_AVX512F && avx512Supported;
 }
 
 namespace hnswlib {

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -37,6 +37,86 @@
 #include <iostream>
 #include <string.h>
 
+// Adapted from https://github.com/Mysticial/FeatureDetector
+#define _XCR_XFEATURE_ENABLED_MASK  0
+#ifdef _WIN32
+void cpuid(int32_t out[4], int32_t eax, int32_t ecx){
+    __cpuidex(out, eax, ecx);
+}
+__int64 xgetbv(unsigned int x){
+    return _xgetbv(x);
+}
+#else
+#include <cpuid.h>
+#include <stdint.h>
+void cpuid(int32_t cpuInfo[4], int32_t eax, int32_t ecx) {
+    __cpuid_count(eax, ecx, cpuInfo[0], cpuInfo[1], cpuInfo[2], cpuInfo[3]);
+}
+
+uint64_t xgetbv(unsigned int index) {
+    uint32_t eax, edx;
+    __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+    return ((uint64_t)edx << 32) | eax;
+}
+#endif
+
+bool AVXCapable() {
+    int cpuInfo[4];
+
+    // CPU support
+    cpuid(cpuInfo, 0, 0);
+    int nIds = cpuInfo[0];
+
+    bool HW_AVX = false;
+    if (nIds >= 0x00000001) {
+        cpuid(cpuInfo, 0x00000001, 0);
+        HW_AVX = (cpuInfo[2] & ((int)1 << 28)) != 0;
+    }
+
+    // OS support
+    cpuid(cpuInfo, 1, 0);
+
+    bool osUsesXSAVE_XRSTORE = (cpuInfo[2] & (1 << 27)) != 0;
+    bool cpuAVXSuport = (cpuInfo[2] & (1 << 28)) != 0;
+
+    bool avxSupported = false;
+    if (osUsesXSAVE_XRSTORE && cpuAVXSuport) {
+        uint64_t xcrFeatureMask = xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+        avxSupported = (xcrFeatureMask & 0x6) == 0x6;
+    }
+    return avxSupported;
+}
+
+bool AVX512Capable() {
+    if (!AVXCapable()) return false;
+
+    int cpuInfo[4];
+
+    // CPU support
+    cpuid(cpuInfo, 0, 0);
+    int nIds = cpuInfo[0];
+
+    bool HW_AVX512F = false;    //  AVX512 Foundation
+    if (nIds >= 0x00000007) {
+        cpuid(cpuInfo, 0x00000007, 0);
+        HW_AVX512F = (cpuInfo[1] & ((int)1 << 16)) != 0;
+    }
+
+    // OS support
+    cpuid(cpuInfo, 1, 0);
+
+    bool osUsesXSAVE_XRSTORE = (cpuInfo[2] & (1 << 27)) != 0;
+    bool cpuAVXSuport = (cpuInfo[2] & (1 << 28)) != 0;
+
+    bool avxSupported = false;
+    bool avx512Supported = false;
+    if (osUsesXSAVE_XRSTORE && cpuAVXSuport) {
+        uint64_t xcrFeatureMask = xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+        avx512Supported = (xcrFeatureMask & 0xe6) == 0xe6;
+    }
+    return avx512Supported;
+}
+
 namespace hnswlib {
     typedef size_t labeltype;
 
@@ -108,7 +188,6 @@ namespace hnswlib {
 
         return result;
     }
-
 }
 
 #include "space_l2.h"

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -297,12 +297,13 @@ namespace hnswlib {
                 InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX512;
             else if (AVXCapable())
                 InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX;
+        #elif defined(USE_AVX)
+            if (AVXCapable())
+                InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX;
         #endif
         #if defined(USE_AVX)
-            if (AVXCapable()) {
-                InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX;
+            if (AVXCapable())
                 InnerProductSIMD4Ext = InnerProductSIMD4ExtAVX;
-            }
         #endif
 
             if (dim % 16 == 0)

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -254,35 +254,35 @@ namespace hnswlib {
     static float
     InnerProductSIMD4Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         DISTFUNC<float> simdfunc_;
-#if defined(USE_AVX)
+    #if defined(USE_AVX)
         if (AVXCapable())
             simdfunc_ = InnerProductSIMD4ExtAVX;
         else
             simdfunc_ = InnerProductSIMD4ExtSSE;
-#else
+    #else
         simdfunc_ = InnerProductSIMD4ExtSSE;
-#endif
+    #endif
         return simdfunc_(pVect1v, pVect2v, qty_ptr);
     }
 
     static float
     InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         DISTFUNC<float> simdfunc_;
-#if defined(USE_AVX512)
+    #if defined(USE_AVX512)
         if (AVX512Capable())
             simdfunc_ = InnerProductSIMD16ExtAVX512;
         else if (AVXCapable())
             simdfunc_ = InnerProductSIMD16ExtAVX;
         else
             simdfunc_ = InnerProductSIMD16ExtSSE;
-#elif defined(USE_AVX)
+    #elif defined(USE_AVX)
         if (AVXCapable())
             simdfunc_ = InnerProductSIMD16ExtAVX;
         else
             simdfunc_ = InnerProductSIMD16ExtSSE;
-#else
+    #else
         simdfunc_ = InnerProductSIMD16ExtSSE;
-#endif
+    #endif
         return simdfunc_(pVect1v, pVect2v, qty_ptr);
     }
 

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -18,7 +18,7 @@ namespace hnswlib {
 
 // Favor using AVX if available.
     static float
-    InnerProductSIMD4Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    InnerProductSIMD4ExtAVX(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         float PORTABLE_ALIGN32 TmpRes[8];
         float *pVect1 = (float *) pVect1v;
         float *pVect2 = (float *) pVect2v;
@@ -64,10 +64,12 @@ namespace hnswlib {
         return 1.0f - sum;
 }
 
-#elif defined(USE_SSE)
+#endif
+
+#if defined(USE_SSE)
 
     static float
-    InnerProductSIMD4Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    InnerProductSIMD4ExtSSE(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         float PORTABLE_ALIGN32 TmpRes[8];
         float *pVect1 = (float *) pVect1v;
         float *pVect2 = (float *) pVect2v;
@@ -128,7 +130,7 @@ namespace hnswlib {
 #if defined(USE_AVX512)
 
     static float
-    InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    InnerProductSIMD16ExtAVX512(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         float PORTABLE_ALIGN64 TmpRes[16];
         float *pVect1 = (float *) pVect1v;
         float *pVect2 = (float *) pVect2v;
@@ -157,10 +159,12 @@ namespace hnswlib {
         return 1.0f - sum;
     }
 
-#elif defined(USE_AVX)
+#endif
+
+#if defined(USE_AVX)
 
     static float
-    InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    InnerProductSIMD16ExtAVX(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         float PORTABLE_ALIGN32 TmpRes[8];
         float *pVect1 = (float *) pVect1v;
         float *pVect2 = (float *) pVect2v;
@@ -195,10 +199,12 @@ namespace hnswlib {
         return 1.0f - sum;
     }
 
-#elif defined(USE_SSE)
+#endif
+
+#if defined(USE_SSE)
 
       static float
-      InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+      InnerProductSIMD16ExtSSE(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         float PORTABLE_ALIGN32 TmpRes[8];
         float *pVect1 = (float *) pVect1v;
         float *pVect2 = (float *) pVect2v;
@@ -245,6 +251,41 @@ namespace hnswlib {
 #endif
 
 #if defined(USE_SSE) || defined(USE_AVX) || defined(USE_AVX512)
+    static float
+    InnerProductSIMD4Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+        DISTFUNC<float> simdfunc_;
+#if defined(USE_AVX)
+        if (AVXCapable())
+            simdfunc_ = InnerProductSIMD4ExtAVX;
+        else
+            simdfunc_ = InnerProductSIMD4ExtSSE;
+#else
+        simdfunc_ = InnerProductSIMD4ExtSSE;
+#endif
+        return simdfunc_(pVect1v, pVect2v, qty_ptr);
+    }
+
+    static float
+    InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+        DISTFUNC<float> simdfunc_;
+#if defined(USE_AVX512)
+        if (AVX512Capable())
+            simdfunc_ = InnerProductSIMD16ExtAVX512;
+        else if (AVXCapable())
+            simdfunc_ = InnerProductSIMD16ExtAVX;
+        else
+            simdfunc_ = InnerProductSIMD16ExtSSE;
+#elif defined(USE_AVX)
+        if (AVXCapable())
+            simdfunc_ = InnerProductSIMD16ExtAVX;
+        else
+            simdfunc_ = InnerProductSIMD16ExtSSE;
+#else
+        simdfunc_ = InnerProductSIMD16ExtSSE;
+#endif
+        return simdfunc_(pVect1v, pVect2v, qty_ptr);
+    }
+
     static float
     InnerProductSIMD16ExtResiduals(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         size_t qty = *((size_t *) qty_ptr);

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -251,40 +251,8 @@ namespace hnswlib {
 #endif
 
 #if defined(USE_SSE) || defined(USE_AVX) || defined(USE_AVX512)
-    static float
-    InnerProductSIMD4Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
-        DISTFUNC<float> simdfunc_;
-    #if defined(USE_AVX)
-        if (AVXCapable())
-            simdfunc_ = InnerProductSIMD4ExtAVX;
-        else
-            simdfunc_ = InnerProductSIMD4ExtSSE;
-    #else
-        simdfunc_ = InnerProductSIMD4ExtSSE;
-    #endif
-        return simdfunc_(pVect1v, pVect2v, qty_ptr);
-    }
-
-    static float
-    InnerProductSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
-        DISTFUNC<float> simdfunc_;
-    #if defined(USE_AVX512)
-        if (AVX512Capable())
-            simdfunc_ = InnerProductSIMD16ExtAVX512;
-        else if (AVXCapable())
-            simdfunc_ = InnerProductSIMD16ExtAVX;
-        else
-            simdfunc_ = InnerProductSIMD16ExtSSE;
-    #elif defined(USE_AVX)
-        if (AVXCapable())
-            simdfunc_ = InnerProductSIMD16ExtAVX;
-        else
-            simdfunc_ = InnerProductSIMD16ExtSSE;
-    #else
-        simdfunc_ = InnerProductSIMD16ExtSSE;
-    #endif
-        return simdfunc_(pVect1v, pVect2v, qty_ptr);
-    }
+    DISTFUNC<float> InnerProductSIMD16Ext = InnerProductSIMD16ExtSSE;
+    DISTFUNC<float> InnerProductSIMD4Ext = InnerProductSIMD4ExtSSE;
 
     static float
     InnerProductSIMD16ExtResiduals(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
@@ -324,6 +292,19 @@ namespace hnswlib {
         InnerProductSpace(size_t dim) {
             fstdistfunc_ = InnerProduct;
     #if defined(USE_AVX) || defined(USE_SSE) || defined(USE_AVX512)
+        #if defined(USE_AVX512)
+            if (AVX512Capable())
+                InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX512;
+            else if (AVXCapable())
+                InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX;
+        #endif
+        #if defined(USE_AVX)
+            if (AVXCapable()) {
+                InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX;
+                InnerProductSIMD4Ext = InnerProductSIMD4ExtAVX;
+            }
+        #endif
+
             if (dim % 16 == 0)
                 fstdistfunc_ = InnerProductSIMD16Ext;
             else if (dim % 4 == 0)

--- a/hnswlib/space_l2.h
+++ b/hnswlib/space_l2.h
@@ -147,21 +147,21 @@ namespace hnswlib {
     static float
     L2SqrSIMD16Ext(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
         DISTFUNC<float> simdfunc_;
-#if defined(USE_AVX512)
+    #if defined(USE_AVX512)
         if (AVX512Capable())
             simdfunc_ = L2SqrSIMD16ExtAVX512;
         else if (AVXCapable())
             simdfunc_ = L2SqrSIMD16ExtAVX;
         else
             simdfunc_ = L2SqrSIMD16ExtSSE;
-#elif defined(USE_AVX)
+    #elif defined(USE_AVX)
         if (AVXCapable())
             simdfunc_ = L2SqrSIMD16ExtAVX;
         else
             simdfunc_ = L2SqrSIMD16ExtSSE;
-#else
+    #else
         simdfunc_ = L2SqrSIMD16ExtSSE;
-#endif
+    #endif
         return simdfunc_(pVect1v, pVect2v, qty_ptr);
     }
 

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,6 @@ class BuildExt(build_ext):
         #'unix': ['-O3', '-march=native'],  # , '-w'
         'unix': ['-O3'],  # , '-w'
     }
-    if "conda" not in sys.version.lower():
-         c_opts['unix'].append("-march=native")
     link_opts = {
         'unix': [],
         'msvc': [],

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,7 @@ class BuildExt(build_ext):
         'unix': ['-O3'],  # , '-w'
     }
     if not os.environ.get("HNSWLIB_NO_NATIVE"):
-        if "conda" not in sys.version.lower():
-            c_opts['unix'].append('-march=native')
+        c_opts['unix'].append('-march=native')
 
     link_opts = {
         'unix': [],

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,10 @@ class BuildExt(build_ext):
         #'unix': ['-O3', '-march=native'],  # , '-w'
         'unix': ['-O3'],  # , '-w'
     }
+    if not os.environ.get("HNSWLIB_NO_CFLAGS"):
+        if "conda" not in sys.version.lower():
+            c_opts['unix'].append('-march=native')
+
     link_opts = {
         'unix': [],
         'msvc': [],

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class BuildExt(build_ext):
         #'unix': ['-O3', '-march=native'],  # , '-w'
         'unix': ['-O3'],  # , '-w'
     }
-    if not os.environ.get("HNSWLIB_NO_CFLAGS"):
+    if not os.environ.get("HNSWLIB_NO_NATIVE"):
         if "conda" not in sys.version.lower():
             c_opts['unix'].append('-march=native')
 

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,11 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
     c_opts = {
         'msvc': ['/EHsc', '/openmp', '/O2'],
-        'unix': ['-O3', '-march=native'],  # , '-w'
+        #'unix': ['-O3', '-march=native'],  # , '-w'
+        'unix': ['-O3'],  # , '-w'
     }
+    if "conda" not in sys.version.lower():
+         c_opts['unix'].append("-march=native")
     link_opts = {
         'unix': [],
         'msvc': [],


### PR DESCRIPTION
Regarding issue https://github.com/nmslib/hnswlib/issues/292
AVX runtime check: I've made a wrapper function for the simd functions and runtime check which to use.  Not the cleanest implementation but I think of a simpler way.

In addition, for issue https://github.com/conda-forge/hnswlib-feedstock/pull/11
I've tested building on one machine and installing in another with different AVX capabilities with both conda and pip.  The '-march=native' in setup.py is a factor in illegal instruction errors.  Taking it out solves this issue.  So I propose a environment flag 'HNSWLIB_NO_NATIVE', which is checked for in setup.py.  This will allow conda build recipes to choose not to use '-march=native'.