### PR TITLE
support for macOS armv8.5-a (MBP M1 Pro/Max)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
     c_opts = {
         'msvc': ['/EHsc', '/openmp', '/O2'],
-        'unix': ['-O3', '-march=native'],  # , '-w'
+        'unix': ['-O3', '-march=armv8.5-a'],  # , '-w'
     }
     link_opts = {
         'unix': [],


### PR DESCRIPTION
With python 3.9.9 for MBP armv8.5-a, this commit could allow successfully installation via "pip install ." in the directory.