### PR TITLE
Disable march=native option when building on Apple M1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 
 import numpy as np
 import pybind11
@@ -82,6 +83,8 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == 'darwin':
+        if platform.machine() == 'arm64':
+            c_opts['unix'].remove('-march=native')
         c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
         link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
     else:


### PR DESCRIPTION
I failed to install hnswlib with pip on Apple M1. The output error message is as follows:

```sh
$ pip install hnswlib
Collecting hnswlib
  Using cached hnswlib-0.6.0.tar.gz (30 kB)

...

Building wheels for collected packages: hnswlib
  Building wheel for hnswlib (pyproject.toml) ... error
  ERROR: Command errored out with exit status 1:

...

  clang: error: the clang compiler does not support '-march=native'
  error: command '/usr/bin/clang' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for hnswlib
Failed to build hnswlib
ERROR: Could not build wheels for hnswlib, which is required to install pyproject.toml-based projects
$
```

The cause of this error is that Apple M1's clang does not support the `march=native` option.  I have fixed setup.py so that the `march=native` option is not given when building on Apple M1. With this fix, I have confirmed that the installation is successful:

```sh
$ pip install .
Processing /Users/yoshoku/hnswlib

...

Building wheels for collected packages: hnswlib
  Building wheel for hnswlib (pyproject.toml) ... done

...

Successfully built hnswlib
Installing collected packages: hnswlib
Successfully installed hnswlib-0.6.0
$
```
