### PR TITLE
Fix exception throwing

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -23,7 +23,7 @@ namespace hnswlib {
             size_per_element_ = data_size_ + sizeof(labeltype);
             data_ = (char *) malloc(maxElements * size_per_element_);
             if (data_ == nullptr)
-                std::runtime_error("Not enough memory: BruteforceSearch failed to allocate data");
+                throw std::runtime_error("Not enough memory: BruteforceSearch failed to allocate data");
             cur_element_count = 0;
         }
 
@@ -140,7 +140,7 @@ namespace hnswlib {
             size_per_element_ = data_size_ + sizeof(labeltype);
             data_ = (char *) malloc(maxelements_ * size_per_element_);
             if (data_ == nullptr)
-                std::runtime_error("Not enough memory: loadIndex failed to allocate data");
+                throw std::runtime_error("Not enough memory: loadIndex failed to allocate data");
 
             input.read(data_, maxelements_ * size_per_element_);
 

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -96,7 +96,7 @@ public:
       l2space = new hnswlib::InnerProductSpace(dim);
       normalize=true;
     } else {
-      throw new std::runtime_error("Space name must be one of l2, ip, or cosine.");
+      throw std::runtime_error("Space name must be one of l2, ip, or cosine.");
     }
     appr_alg = NULL;
     ep_added = true;
@@ -129,7 +129,7 @@ public:
 
     void init_new_index(const size_t maxElements, const size_t M, const size_t efConstruction, const size_t random_seed) {
         if (appr_alg) {
-            throw new std::runtime_error("The index is already initiated.");
+            throw std::runtime_error("The index is already initiated.");
         }
         cur_l = 0;
         appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, maxElements, M, efConstruction, random_seed);
@@ -668,7 +668,7 @@ public:
             space = new hnswlib::InnerProductSpace(dim);
             normalize=true;
         } else {
-            throw new std::runtime_error("Space name must be one of l2, ip, or cosine.");
+            throw std::runtime_error("Space name must be one of l2, ip, or cosine.");
         }
         alg = NULL;
         index_inited = false;
@@ -693,7 +693,7 @@ public:
 
     void init_new_index(const size_t maxElements) {
         if (alg) {
-            throw new std::runtime_error("The index is already initiated.");
+            throw std::runtime_error("The index is already initiated.");
         }
         cur_l = 0;
         alg = new hnswlib::BruteforceSearch<dist_t>(space, maxElements);


### PR DESCRIPTION
This pull request fixes exception throwing. For example, this pull request changes make the error messages appropriate.

Currently release version:

```python
>>> import hnswlib
>>> p = hnswlib.Index(space='foo', dim=8)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Caught an unknown exception!
>>> p = hnswlib.Index(space='l2', dim=8)
>>> p.init_index(max_elements=8)
>>> p.init_index(max_elements=8)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Caught an unknown exception!
>>>
```

Applying this pull request changes:

```python
>>> import hnswlib
>>> p = hnswlib.Index(space='foo', dim=8)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Space name must be one of l2, ip, or cosine.
>>> p = hnswlib.Index(space='l2', dim=8)
>>> p.init_index(max_elements=8)
>>> p.init_index(max_elements=8)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: The index is already initiated.
>>>