### PR TITLE
add missing quote on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Please make pull requests against the `develop` branch.
 
 When making changes please run tests (and please add a test to `python_bindings/tests` in case there is new functionality):
 ```bash
-python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py
+python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py"
 ```
 
 


### PR DESCRIPTION
a trivial fix to the `README.md` where the final quote on the python test invocation was missing.