### PR TITLE
initialize fields in constructor

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -8,10 +8,14 @@ namespace hnswlib {
     template<typename dist_t>
     class BruteforceSearch : public AlgorithmInterface<dist_t> {
     public:
-        BruteforceSearch(SpaceInterface <dist_t> *s) {
+        BruteforceSearch(SpaceInterface <dist_t> *s) : data_(nullptr), maxelements_(0), 
+        cur_element_count(0), size_per_element_(0), data_size_(0), 
+        dist_func_param_(nullptr) {
 
         }
-        BruteforceSearch(SpaceInterface<dist_t> *s, const std::string &location) {
+        BruteforceSearch(SpaceInterface<dist_t> *s, const std::string &location) : 
+        data_(nullptr), maxelements_(0), cur_element_count(0), size_per_element_(0), 
+        data_size_(0), dist_func_param_(nullptr) {
             loadIndex(location, s);
         }
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -17,15 +17,34 @@ namespace hnswlib {
     class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     public:
         static const tableint max_update_element_locks = 65536;
-        HierarchicalNSW(SpaceInterface<dist_t> *s) {
+        HierarchicalNSW(SpaceInterface<dist_t> *s) : 
+        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
+        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
+        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
+        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
+        offsetData_(0), offsetLevel0_(0), 
+        data_level0_memory_(nullptr), 
+        linkLists_(nullptr), data_size_(0), label_offset_(0), 
+        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
+        ef_(0){
         }
 
-        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) {
+        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) :
+        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
+        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
+        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
+        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
+        offsetData_(0), offsetLevel0_(0), 
+        data_level0_memory_(nullptr), 
+        linkLists_(nullptr), data_size_(0), label_offset_(0), 
+        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
+        ef_(0) {
             loadIndex(location, s, max_elements);
         }
 
         HierarchicalNSW(SpaceInterface<dist_t> *s, size_t max_elements, size_t M = 16, size_t ef_construction = 200, size_t random_seed = 100) :
-                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements) {
+                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements),
+                metric_distance_computations(0), metric_hops(0) {
             max_elements_ = max_elements;
 
             num_deleted_ = 0;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -17,34 +17,15 @@ namespace hnswlib {
     class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     public:
         static const tableint max_update_element_locks = 65536;
-        HierarchicalNSW(SpaceInterface<dist_t> *s) : 
-        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
-        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
-        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
-        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
-        offsetData_(0), offsetLevel0_(0), 
-        data_level0_memory_(nullptr), 
-        linkLists_(nullptr), data_size_(0), label_offset_(0), 
-        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
-        ef_(0){
+        HierarchicalNSW(SpaceInterface<dist_t> *s) {
         }
 
-        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) :
-        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
-        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
-        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
-        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
-        offsetData_(0), offsetLevel0_(0), 
-        data_level0_memory_(nullptr), 
-        linkLists_(nullptr), data_size_(0), label_offset_(0), 
-        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
-        ef_(0) {
+        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) {
             loadIndex(location, s, max_elements);
         }
 
         HierarchicalNSW(SpaceInterface<dist_t> *s, size_t max_elements, size_t M = 16, size_t ef_construction = 200, size_t random_seed = 100) :
-                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements),
-                metric_distance_computations(0), metric_hops(0) {
+                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements) {
             max_elements_ = max_elements;
 
             num_deleted_ = 0;
@@ -104,22 +85,21 @@ namespace hnswlib {
             delete visited_list_pool_;
         }
 
-        size_t max_elements_;
-        size_t cur_element_count;
-        size_t size_data_per_element_;
-        size_t size_links_per_element_;
-        size_t num_deleted_;
+        size_t max_elements_{0};
+        size_t cur_element_count{0};
+        size_t size_data_per_element_{0};
+        size_t size_links_per_element_{0};
+        size_t num_deleted_{0};
+        size_t M_{0};
+        size_t maxM_{0};
+        size_t maxM0_{0};
+        size_t ef_construction_{0};
 
-        size_t M_;
-        size_t maxM_;
-        size_t maxM0_;
-        size_t ef_construction_;
-
-        double mult_, revSize_;
-        int maxlevel_;
+        double mult_{0.0}, revSize_{0.0};
+        int maxlevel_{0};
 
 
-        VisitedListPool *visited_list_pool_;
+        VisitedListPool *visited_list_pool_{nullptr};
         std::mutex cur_element_count_guard_;
 
         std::vector<std::mutex> link_list_locks_;
@@ -127,20 +107,20 @@ namespace hnswlib {
         // Locks to prevent race condition during update/insert of an element at same time.
         // Note: Locks for additions can also be used to prevent this race condition if the querying of KNN is not exposed along with update/inserts i.e multithread insert/update/query in parallel.
         std::vector<std::mutex> link_list_update_locks_;
-        tableint enterpoint_node_;
+        tableint enterpoint_node_{0};
 
-        size_t size_links_level0_;
-        size_t offsetData_, offsetLevel0_;
+        size_t size_links_level0_{0};
+        size_t offsetData_{0}, offsetLevel0_{0};
 
-        char *data_level0_memory_;
-        char **linkLists_;
+        char *data_level0_memory_{nullptr};
+        char **linkLists_{nullptr};
         std::vector<int> element_levels_;
 
-        size_t data_size_;
+        size_t data_size_{0};
 
-        size_t label_offset_;
+        size_t label_offset_{0};
         DISTFUNC<dist_t> fstdistfunc_;
-        void *dist_func_param_;
+        void *dist_func_param_{nullptr};
         std::unordered_map<labeltype, tableint> label_lookup_;
 
         std::default_random_engine level_generator_;
@@ -253,8 +233,8 @@ namespace hnswlib {
             return top_candidates;
         }
 
-        mutable std::atomic<long> metric_distance_computations;
-        mutable std::atomic<long> metric_hops;
+        mutable std::atomic<long> metric_distance_computations{0};
+        mutable std::atomic<long> metric_hops{0};
 
         template <bool has_deletions, bool collect_metrics=false>
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
@@ -523,7 +503,7 @@ namespace hnswlib {
         }
 
         std::mutex global;
-        size_t ef_;
+        size_t ef_{0};
 
         void setEf(size_t ef) {
             ef_ = ef;


### PR DESCRIPTION
Fixes #393.

Testing: I ran `make test` and got no different results between the output in this PR and the current state of `develop`. That said I do see these warnings in the output (these are *also* present in `develop`):

```
.Adding all elements (10000)
.Running pickle tests for <hnswlib.Index(space='cosine', dim=32)>
.Running pickle tests for <hnswlib.Index(space='ip', dim=16)>
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 ann distance values are different from brute-force values (total # of values=2500, dists_thresh=50)
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 labels are missing from ann results (k=25, err_thresh=5)
Warning: 1 ann distance values are different from brute-force values (total # of values=2500, dists_thresh=50)
```

I am not sure if this is an actual problem or not?

Also, I confirmed that the valgrind error disappears via testing through the R bindings I maintain.
