### PR TITLE
Filter elements with an optional filtering function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,5 +46,6 @@ jobs:
         run: |
           cd build
           ./searchKnnCloserFirst_test
+          ./searchKnnWithFilter_test
           ./test_updates
           ./test_updates update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_executable(searchKnnCloserFirst_test examples/searchKnnCloserFirst_test.cpp)
     target_link_libraries(searchKnnCloserFirst_test hnswlib)
 
+    add_executable(searchKnnWithFilter_test examples/searchKnnWithFilter_test.cpp)
+    target_link_libraries(searchKnnWithFilter_test hnswlib)
+
     add_executable(main main.cpp sift_1b.cpp)
     target_link_libraries(main hnswlib)
 endif()

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -21,7 +21,7 @@ bool pickIdsDivisibleBySeven(unsigned int ep_id) {
 }
 
 template<typename filter_func_t>
-void test(filter_func_t filter_func, size_t div_num) {
+void test(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
     int d = 4;
     idx_t n = 100;
     idx_t nq = 10;
@@ -40,15 +40,15 @@ void test(filter_func_t filter_func, size_t div_num) {
     for (idx_t i = 0; i < nq * d; ++i) {
         query[i] = distrib(rng);
     }
-      
 
     hnswlib::L2Space space(d);
     hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float,hnswlib::FILTERFUNC>(&space, 2 * n);
     hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float,hnswlib::FILTERFUNC>(&space, 2 * n);
 
     for (size_t i = 0; i < n; ++i) {
-        alg_brute->addPoint(data.data() + d * i, i);
-        alg_hnsw->addPoint(data.data() + d * i, i);
+        // `label_id_start` is used to ensure that the returned IDs are labels and not internal IDs
+        alg_brute->addPoint(data.data() + d * i, label_id_start + i);
+        alg_hnsw->addPoint(data.data() + d * i, label_id_start + i);
     }
 
     // test searchKnnCloserFirst of BruteforceSearch with filtering
@@ -87,8 +87,8 @@ void test(filter_func_t filter_func, size_t div_num) {
 
 int main() {
     std::cout << "Testing ..." << std::endl;
-    test(pickIdsDivisibleByThree, 3);
-    test(pickIdsDivisibleBySeven, 7);
+    test(pickIdsDivisibleByThree, 3, 17);
+    test(pickIdsDivisibleBySeven, 7, 17);
     std::cout << "Test ok" << std::endl;
 
     return 0;

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -12,16 +12,20 @@ namespace
 
 using idx_t = hnswlib::labeltype;
 
-bool pickIdsDivisibleByThree(unsigned int ep_id) {
-    return ep_id % 3 == 0;
+bool pickIdsDivisibleByThree(unsigned int label_id) {
+    return label_id % 3 == 0;
 }
 
-bool pickIdsDivisibleBySeven(unsigned int ep_id) {
-    return ep_id % 7 == 0;
+bool pickIdsDivisibleBySeven(unsigned int label_id) {
+    return label_id % 7 == 0;
+}
+
+bool pickNothing(unsigned int label_id) {
+    return false;
 }
 
 template<typename filter_func_t>
-void test(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
+void test_some_filtering(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
     int d = 4;
     idx_t n = 100;
     idx_t nq = 10;
@@ -83,12 +87,71 @@ void test(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
     delete alg_hnsw;
 }
 
+template<typename filter_func_t>
+void test_none_filtering(filter_func_t filter_func, size_t label_id_start) {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+
+    std::vector<float> data(n * d);
+    std::vector<float> query(nq * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib;
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+    for (idx_t i = 0; i < nq * d; ++i) {
+        query[i] = distrib(rng);
+    }
+
+    hnswlib::L2Space space(d);
+    hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+    hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+
+    for (size_t i = 0; i < n; ++i) {
+        // `label_id_start` is used to ensure that the returned IDs are labels and not internal IDs
+        alg_brute->addPoint(data.data() + d * i, label_id_start + i);
+        alg_hnsw->addPoint(data.data() + d * i, label_id_start + i);
+    }
+
+    // test searchKnnCloserFirst of BruteforceSearch with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_brute->searchKnn(p, k, filter_func);
+        auto res = alg_brute->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        assert(0 == gd.size());
+    }
+
+    // test searchKnnCloserFirst of hnsw with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_hnsw->searchKnn(p, k, filter_func);
+        auto res = alg_hnsw->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        assert(0 == gd.size());
+    }
+
+    delete alg_brute;
+    delete alg_hnsw;
+}
+
 } // namespace
 
 int main() {
     std::cout << "Testing ..." << std::endl;
-    test(pickIdsDivisibleByThree, 3, 17);
-    test(pickIdsDivisibleBySeven, 7, 17);
+
+    // some of the elements are filtered
+    test_some_filtering(pickIdsDivisibleByThree, 3, 17);
+    test_some_filtering(pickIdsDivisibleBySeven, 7, 17);
+
+    // all of the elements are filtered
+    test_none_filtering(pickNothing, 17);
+
     std::cout << "Test ok" << std::endl;
 
     return 0;

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -148,7 +148,7 @@ class CustomFilterFunctor: public hnswlib::FilterFunctor {
 public:
     explicit CustomFilterFunctor(const std::unordered_set<unsigned int>& values) : allowed_values(values) {}
 
-    constexpr bool operator()(unsigned int id) const {
+    bool operator()(unsigned int id) {
         return allowed_values.count(id) != 0;
     }
 };

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -1,0 +1,95 @@
+// This is a test file for testing the filtering feature
+
+#include "../hnswlib/hnswlib.h"
+
+#include <assert.h>
+
+#include <vector>
+#include <iostream>
+
+namespace
+{
+
+using idx_t = hnswlib::labeltype;
+
+bool pickIdsDivisibleByThree(unsigned int ep_id) {
+    return ep_id % 3 == 0;
+}
+
+bool pickIdsDivisibleBySeven(unsigned int ep_id) {
+    return ep_id % 7 == 0;
+}
+
+template<typename filter_func_t>
+void test(filter_func_t filter_func, size_t div_num) {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+   
+    std::vector<float> data(n * d);
+    std::vector<float> query(nq * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib;
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+    for (idx_t i = 0; i < nq * d; ++i) {
+        query[i] = distrib(rng);
+    }
+      
+
+    hnswlib::L2Space space(d);
+    hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+    hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+
+    for (size_t i = 0; i < n; ++i) {
+        alg_brute->addPoint(data.data() + d * i, i);
+        alg_hnsw->addPoint(data.data() + d * i, i);
+    }
+
+    // test searchKnnCloserFirst of BruteforceSearch with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_brute->searchKnn(p, k, filter_func);
+        auto res = alg_brute->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        size_t t = gd.size();
+        while (!gd.empty()) {
+            assert(gd.top() == res[--t]);
+            assert((gd.top().second % div_num) == 0);
+            gd.pop();
+        }
+    }
+
+    // test searchKnnCloserFirst of hnsw with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_hnsw->searchKnn(p, k, filter_func);
+        auto res = alg_hnsw->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        size_t t = gd.size();
+        while (!gd.empty()) {
+            assert(gd.top() == res[--t]);
+            assert((gd.top().second % div_num) == 0);
+            gd.pop();
+        }
+    }
+    
+    delete alg_brute;
+    delete alg_hnsw;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "Testing ..." << std::endl;
+    test(pickIdsDivisibleByThree, 3);
+    test(pickIdsDivisibleBySeven, 7);
+    std::cout << "Test ok" << std::endl;
+
+    return 0;
+}

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 namespace hnswlib {
-    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    template<typename dist_t, typename filter_func_t=FilterFunctor>
     class BruteforceSearch : public AlgorithmInterface<dist_t,filter_func_t> {
     public:
         BruteforceSearch(SpaceInterface <dist_t> *s) : data_(nullptr), maxelements_(0), 
@@ -92,7 +92,7 @@ namespace hnswlib {
 
 
         std::priority_queue<std::pair<dist_t, labeltype >>
-        searchKnn(const void *query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const {
+        searchKnn(const void *query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const {
             std::priority_queue<std::pair<dist_t, labeltype >> topResults;
             if (cur_element_count == 0) return topResults;
             for (int i = 0; i < k; i++) {

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -102,7 +102,7 @@ namespace hnswlib {
                     topResults.push(std::pair<dist_t, labeltype>(dist, label));
                 }
             }
-            dist_t lastdist = topResults.top().first;
+            dist_t lastdist = topResults.empty() ? std::numeric_limits<dist_t>::max() : topResults.top().first;
             for (int i = k; i < cur_element_count; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 if (dist <= lastdist) {
@@ -112,7 +112,10 @@ namespace hnswlib {
                     }
                     if (topResults.size() > k)
                         topResults.pop();
-                    lastdist = topResults.top().first;
+
+                    if (!topResults.empty()) {
+                        lastdist = topResults.top().first;
+                    }
                 }
 
             }

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -93,12 +93,14 @@ namespace hnswlib {
 
         std::priority_queue<std::pair<dist_t, labeltype >>
         searchKnn(const void *query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const {
+            assert(k <= cur_element_count);
             std::priority_queue<std::pair<dist_t, labeltype >> topResults;
             if (cur_element_count == 0) return topResults;
+            bool is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
             for (int i = 0; i < k; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 labeltype label = *((labeltype*) (data_ + size_per_element_ * i + data_size_));
-                if(isIdAllowed(label)) {
+                if(is_filter_disabled || isIdAllowed(label)) {
                     topResults.push(std::pair<dist_t, labeltype>(dist, label));
                 }
             }
@@ -107,7 +109,7 @@ namespace hnswlib {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 if (dist <= lastdist) {
                     labeltype label = *((labeltype *) (data_ + size_per_element_ * i + data_size_));
-                    if(isIdAllowed(label)) {
+                    if(is_filter_disabled || isIdAllowed(label)) {
                         topResults.push(std::pair<dist_t, labeltype>(dist, label));
                     }
                     if (topResults.size() > k)

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <mutex>
 #include <algorithm>
+#include <assert.h>
 
 namespace hnswlib {
     template<typename dist_t, typename filter_func_t=FilterFunctor>

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -308,7 +308,6 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
                             if ((!has_deletions || !isMarkedDeleted(candidate_id)) && (is_filter_disabled || isIdAllowed(getExternalLabel(candidate_id))))
                                 top_candidates.emplace(dist, candidate_id);
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -247,7 +247,8 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
 
             dist_t lowerBound;
-            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(getExternalLabel(ep_id))) {
+            bool is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
+            if ((!has_deletions || !isMarkedDeleted(ep_id)) && (is_filter_disabled || isIdAllowed(getExternalLabel(ep_id)))) {
                 dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
                 lowerBound = dist;
                 top_candidates.emplace(dist, ep_id);
@@ -307,7 +308,8 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(getExternalLabel(candidate_id)))
+                            is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
+                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && (is_filter_disabled || isIdAllowed(getExternalLabel(candidate_id))))
                                 top_candidates.emplace(dist, candidate_id);
 
                             if (top_candidates.size() > ef)

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -13,7 +13,7 @@ namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
 
-    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    template<typename dist_t, typename filter_func_t=FilterFunctor>
     class HierarchicalNSW : public AlgorithmInterface<dist_t,filter_func_t> {
     public:
         static const tableint max_update_element_locks = 65536;
@@ -238,7 +238,7 @@ namespace hnswlib {
 
         template <bool has_deletions, bool collect_metrics=false>
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
-        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef, filter_func_t isIdAllowed) const {
+        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef, filter_func_t& isIdAllowed) const {
             VisitedList *vl = visited_list_pool_->getFreeVisitedList();
             vl_type *visited_array = vl->mass;
             vl_type visited_array_tag = vl->curV;
@@ -1111,7 +1111,7 @@ namespace hnswlib {
         };
 
         std::priority_queue<std::pair<dist_t, labeltype >>
-        searchKnn(const void *query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const {
+        searchKnn(const void *query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const {
             std::priority_queue<std::pair<dist_t, labeltype >> result;
             if (cur_element_count == 0) return result;
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -247,7 +247,7 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
 
             dist_t lowerBound;
-            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(ep_id)) {
+            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(getExternalLabel(ep_id))) {
                 dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
                 lowerBound = dist;
                 top_candidates.emplace(dist, ep_id);
@@ -307,7 +307,7 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(candidate_id))
+                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(getExternalLabel(candidate_id)))
                                 top_candidates.emplace(dist, candidate_id);
 
                             if (top_candidates.size() > ef)

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -13,8 +13,8 @@ namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
 
-    template<typename dist_t>
-    class HierarchicalNSW : public AlgorithmInterface<dist_t> {
+    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    class HierarchicalNSW : public AlgorithmInterface<dist_t,filter_func_t> {
     public:
         static const tableint max_update_element_locks = 65536;
         HierarchicalNSW(SpaceInterface<dist_t> *s) {
@@ -238,7 +238,7 @@ namespace hnswlib {
 
         template <bool has_deletions, bool collect_metrics=false>
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
-        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef) const {
+        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef, filter_func_t isIdAllowed) const {
             VisitedList *vl = visited_list_pool_->getFreeVisitedList();
             vl_type *visited_array = vl->mass;
             vl_type visited_array_tag = vl->curV;
@@ -247,7 +247,7 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
 
             dist_t lowerBound;
-            if (!has_deletions || !isMarkedDeleted(ep_id)) {
+            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(ep_id)) {
                 dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
                 lowerBound = dist;
                 top_candidates.emplace(dist, ep_id);
@@ -307,7 +307,7 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            if (!has_deletions || !isMarkedDeleted(candidate_id))
+                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(candidate_id))
                                 top_candidates.emplace(dist, candidate_id);
 
                             if (top_candidates.size() > ef)
@@ -1111,7 +1111,7 @@ namespace hnswlib {
         };
 
         std::priority_queue<std::pair<dist_t, labeltype >>
-        searchKnn(const void *query_data, size_t k) const {
+        searchKnn(const void *query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const {
             std::priority_queue<std::pair<dist_t, labeltype >> result;
             if (cur_element_count == 0) return result;
 
@@ -1148,11 +1148,11 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
             if (num_deleted_) {
                 top_candidates=searchBaseLayerST<true,true>(
-                        currObj, query_data, std::max(ef_, k));
+                        currObj, query_data, std::max(ef_, k), isIdAllowed);
             }
             else{
                 top_candidates=searchBaseLayerST<false,true>(
-                        currObj, query_data, std::max(ef_, k));
+                        currObj, query_data, std::max(ef_, k), isIdAllowed);
             }
 
             while (top_candidates.size() > k) {

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -122,7 +122,7 @@ namespace hnswlib {
         bool operator()(Args&&...) { return true; }
     };
 
-    FilterFunctor allowAllIds;
+    static FilterFunctor allowAllIds;
 
     template <typename T>
     class pairGreater {

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -116,7 +116,7 @@ static bool AVX512Capable() {
 namespace hnswlib {
     typedef size_t labeltype;
 
-    bool allowAllIds(unsigned int ep_id) {
+    static bool allowAllIds(unsigned int ep_id) {
         return true;
     }
 

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -116,9 +116,13 @@ static bool AVX512Capable() {
 namespace hnswlib {
     typedef size_t labeltype;
 
-    static bool allowAllIds(unsigned int ep_id) {
-        return true;
-    }
+    // This can be extended to store state for filtering (e.g. from a std::set)
+    struct FilterFunctor {
+        template<class...Args>
+        bool operator()(Args&&...) { return true; }
+    };
+
+    FilterFunctor allowAllIds;
 
     template <typename T>
     class pairGreater {
@@ -141,8 +145,6 @@ namespace hnswlib {
     template<typename MTYPE>
     using DISTFUNC = MTYPE(*)(const void *, const void *, const void *);
 
-    using FILTERFUNC = bool(*)(unsigned int);
-
     template<typename MTYPE>
     class SpaceInterface {
     public:
@@ -156,17 +158,17 @@ namespace hnswlib {
         virtual ~SpaceInterface() {}
     };
 
-    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    template<typename dist_t, typename filter_func_t=FilterFunctor>
     class AlgorithmInterface {
     public:
         virtual void addPoint(const void *datapoint, labeltype label)=0;
 
         virtual std::priority_queue<std::pair<dist_t, labeltype >>
-            searchKnn(const void*, size_t, filter_func_t isIdAllowed=allowAllIds) const = 0;
+            searchKnn(const void*, size_t, filter_func_t& isIdAllowed=allowAllIds) const = 0;
 
         // Return k nearest neighbor in the order of closer fist
         virtual std::vector<std::pair<dist_t, labeltype>>
-            searchKnnCloserFirst(const void* query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const;
+            searchKnnCloserFirst(const void* query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const;
 
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){
@@ -176,7 +178,7 @@ namespace hnswlib {
     template<typename dist_t, typename filter_func_t>
     std::vector<std::pair<dist_t, labeltype>>
     AlgorithmInterface<dist_t, filter_func_t>::searchKnnCloserFirst(const void* query_data, size_t k,
-                                                                    filter_func_t isIdAllowed) const {
+                                                                    filter_func_t& isIdAllowed) const {
         std::vector<std::pair<dist_t, labeltype>> result;
 
         // here searchKnn returns the result in the order of further first


### PR DESCRIPTION
Fixes https://github.com/nmslib/hnswlib/issues/366

**Summary of the change**

An optional filtering function can be specified as a template parameter that determines if a given ID should be picked. The default is a function that allows all labels via a`return true` -- this will be optimised away by the compiler, so there will be no extra cost for those who don't provide a filtering function. 

The use of a templated filter function also ensures that the filtering logic can be entirely inlined by the compiler, and is an implementation detail, instead of forcing a `std::set<>` of allowed IDs as discussed in #366.

I've added a test that asserts on both the brute force and hnsw implementations. Verified that existing search knn tests pass.