### PR TITLE
add tag search

### DIFF
--- a/hnswpf/hnsw_core.h
+++ b/hnswpf/hnsw_core.h
@@ -2,8 +2,20 @@
 #ifndef HNSWPF_CORE_H_
 #define HNSWPF_CORE_H_
 
-#include <dirent.h>
+#if defined(_WIN32)
+#include <direct.h>
+#include <io.h>
+#define MKDIR(a) _mkdir((a))
+#define FILE_SEPARATOR "\\"
+#else
+
 #include <ftw.h>
+
+#define FILE_SEPARATOR "/"
+#define MKDIR(a) mkdir((a),0755)
+
+#endif
+
 #include "hnswlib.h"
 #include "hnswalg.h"
 
@@ -324,11 +336,9 @@ public:
     // saveIndex
     void saveIndex(const std::string &dir) {
         // if not exist, then create
-        if (nullptr == opendir(dir.c_str())) {
-            mkdir(dir.c_str(), 0755);
-        }
-        std::string vec_index_path = dir + "/" + INDEX_NAME_VEC;
-        std::string tag_index_path = dir + "/" + INDEX_NAME_TAG;
+        MKDIR(dir.c_str());
+        std::string vec_index_path = dir + FILE_SEPARATOR + INDEX_NAME_VEC;
+        std::string tag_index_path = dir + FILE_SEPARATOR + INDEX_NAME_TAG;
 
         HierarchicalNSW<dist_t>::saveIndex(vec_index_path);
 
@@ -346,8 +356,8 @@ public:
 
     // loadIndex
     void loadIndex(const std::string &dir, SpaceInterface <dist_t> *s, size_t max_elements_i = 0) {
-        std::string vec_index_path = dir + "/" + INDEX_NAME_VEC;
-        std::string tag_index_path = dir + "/" + INDEX_NAME_TAG;
+        std::string vec_index_path = dir + FILE_SEPARATOR + INDEX_NAME_VEC;
+        std::string tag_index_path = dir + FILE_SEPARATOR + INDEX_NAME_TAG;
 
         HierarchicalNSW<dist_t>::loadIndex(vec_index_path, s, max_elements_i);
 

--- a/hnswpf/hnsw_core.h
+++ b/hnswpf/hnsw_core.h
@@ -1,0 +1,376 @@
+
+#ifndef HNSWPF_CORE_H_
+#define HNSWPF_CORE_H_
+
+#include <dirent.h>
+#include <ftw.h>
+#include "hnswlib.h"
+#include "hnswalg.h"
+
+#include "hnsw_tags.h"
+#include "hnsw_query.h"
+
+namespace hnswlib {
+
+
+const static std::string INDEX_NAME_VEC = "hnsw_vec.bin";
+const static std::string INDEX_NAME_TAG = "hnsw_tag.bin";
+
+
+template<typename dist_t>
+class SearchHNSW : public HierarchicalNSW<dist_t> {
+public:
+    // parent param
+    using HierarchicalNSW<dist_t>::element_levels_;
+    using HierarchicalNSW<dist_t>::cur_element_count;
+    using HierarchicalNSW<dist_t>::getDataByInternalId;
+    using HierarchicalNSW<dist_t>::dist_func_param_;
+    using HierarchicalNSW<dist_t>::get_linklist;
+    using HierarchicalNSW<dist_t>::getListCount;
+    using HierarchicalNSW<dist_t>::metric_hops;
+    using HierarchicalNSW<dist_t>::metric_distance_computations;
+    using HierarchicalNSW<dist_t>::max_elements_;
+    using HierarchicalNSW<dist_t>::num_deleted_;
+    using HierarchicalNSW<dist_t>::ef_;
+    using HierarchicalNSW<dist_t>::enterpoint_node_;
+    using HierarchicalNSW<dist_t>::getExternalLabel;
+    using HierarchicalNSW<dist_t>::label_lookup_;
+    using HierarchicalNSW<dist_t>::visited_list_pool_;
+    using HierarchicalNSW<dist_t>::isMarkedDeleted;
+    using HierarchicalNSW<dist_t>::get_linklist0;
+    using HierarchicalNSW<dist_t>::data_level0_memory_;
+    using HierarchicalNSW<dist_t>::size_data_per_element_;
+    using HierarchicalNSW<dist_t>::offsetData_;
+    using HierarchicalNSW<dist_t>::offsetLevel0_;
+    using HierarchicalNSW<dist_t>::fstdistfunc_;
+    using HierarchicalNSW<dist_t>::searchKnn;
+    using HierarchicalNSW<dist_t>::maxM_;
+    using HierarchicalNSW<dist_t>::maxM0_;
+    using HierarchicalNSW<dist_t>::maxlevel_;
+
+    // child param
+    // invert dic
+    std::unordered_map<std::string, hnswlib::TagIndex> tag_index_dict;
+
+    // tag lock
+    std::mutex  tag_lock;
+
+
+public:
+    SearchHNSW(SpaceInterface <dist_t> *s,
+                size_t max_elements, size_t M = 16,
+                size_t ef_construction = 200, size_t random_seed = 100) :
+                HierarchicalNSW<dist_t>(s, max_elements, M, ef_construction, random_seed) {}
+
+    void addPoint(const void *data_point, labeltype external_id) {
+        HierarchicalNSW<dist_t>::addPoint(data_point, external_id, -1);
+    }
+
+
+    //  addFieldTag support parallel
+    void addFieldTag(int external_id, const std::string &field, int tag) {
+        // 1、double check field
+        TagIndex &tagIndex = tag_index_dict[field];
+        if (tagIndex.name.empty()) {
+            std::lock_guard<std::mutex> lock(tag_lock);
+            if (tagIndex.name.empty()) {
+                tagIndex.name = field;
+                tagIndex.tag_to_externals[tag] = {external_id};
+                return;
+            }
+        }
+
+        // 2、insert tag
+        tagIndex.insert(tag, external_id);
+    }
+
+
+    std::priority_queue<std::pair<dist_t, labeltype >>
+    searchKnn(const void *query_data, size_t k, const std::list<QueryFilter> &queryFilters) const {
+        std::priority_queue<std::pair<dist_t, labeltype >> result;
+        if (cur_element_count == 0) return result;
+
+        tableint currObj = enterpoint_node_;
+        dist_t curdist = fstdistfunc_(query_data, getDataByInternalId(currObj), dist_func_param_);
+
+        for (int level = maxlevel_; level > 0; level--) {
+            bool changed = true;
+            while (changed) {
+                changed = false;
+                unsigned int *data;
+
+                data = (unsigned int *) get_linklist(currObj, level);
+                int size = getListCount(data);
+                metric_hops++;
+                metric_distance_computations += size;
+
+                tableint *datal = (tableint *) (data + 1);
+                for (int i = 0; i < size; i++) {
+                    tableint cand = datal[i];
+                    if (cand < 0 || cand > max_elements_) {
+                        throw std::runtime_error("cand error");
+                    }
+
+                    dist_t d = fstdistfunc_(query_data, getDataByInternalId(cand), dist_func_param_);
+                    if (d < curdist) {
+                        curdist = d;
+                        currObj = cand;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
+        if (num_deleted_) {
+            top_candidates = searchBaseLayerST<true, true>(currObj, query_data, std::max(ef_, k), queryFilters);
+        } else {
+            top_candidates = searchBaseLayerST<false, true>(currObj, query_data, std::max(ef_, k), queryFilters);
+        }
+
+        while (top_candidates.size() > k) {
+            top_candidates.pop();
+        }
+        while (top_candidates.size() > 0) {
+            const std::pair<dist_t, tableint> &rez = top_candidates.top();
+            result.push(std::pair<dist_t, labeltype>(rez.first, getExternalLabel(rez.second)));
+            top_candidates.pop();
+        }
+        return result;
+    }
+
+
+    inline bool checkCondition(const tableint &external_id, const std::list<QueryFilter> &queryFilters) const {
+        if (queryFilters.empty()) {
+            return true;
+        }
+
+        bool result = true;
+        for (const QueryFilter &queryFilter: queryFilters) {
+            bool tmp_res = false;
+            if (queryFilter.excludes.empty() && queryFilter.includes.empty()) {
+                continue;
+            }
+
+            // id pre filter
+            if (queryFilter.name == "ID") {
+                // tag check： Subset is or
+                if (queryFilter.excludes.find(external_id) == queryFilter.excludes.end()) {
+                    continue;
+                }
+                if (queryFilter.includes.find(external_id) != queryFilter.includes.end()) {
+                    continue;
+                }
+            } else {
+                const auto &it = tag_index_dict.find(queryFilter.name);
+                if (!queryFilter.excludes.empty() && it == tag_index_dict.end()) {
+                    continue;
+                }
+
+                if (it != tag_index_dict.end()) {
+                    const TagIndex &tag_index = it->second;
+                    for (int tag : queryFilter.includes) {
+                        const auto &tag_candidates_it = tag_index.tag_to_externals.find(tag);
+                        if (tag_candidates_it != tag_index.tag_to_externals.end()) {
+                            const std::unordered_set<int> &tag_candidates = tag_candidates_it->second;
+                            if (tag_candidates.count((int) external_id) > 0) {
+                                tmp_res = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (tmp_res) {
+                        continue;
+                    }
+
+                    for (int tag : queryFilter.excludes) {
+                        const auto &tag_candidates_it = tag_index.tag_to_externals.find(tag);
+                        if (tag_candidates_it == tag_index.tag_to_externals.end()) {
+                            tmp_res = true;
+                            break;
+                        }
+                        if (tag_candidates_it != tag_index.tag_to_externals.end()) {
+                            const std::unordered_set<int> &tag_candidates = tag_candidates_it->second;
+                            if (tag_candidates.count((int) external_id) == 0) {
+                                tmp_res = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (tmp_res) {
+                        continue;
+                    }
+                }
+            }
+
+            return false;
+        }
+        return result;
+    }
+
+
+    tableint getInternalId(int external_id) const {
+        auto search = label_lookup_.find(external_id);
+        if (search == label_lookup_.end()) {
+            throw std::runtime_error("Label not found");
+        }
+        return search->second;
+    }
+
+    struct CompareByFirst {
+        constexpr bool operator()(std::pair<dist_t, tableint> const &a,
+                                  std::pair<dist_t, tableint> const &b) const noexcept {
+            return a.first < b.first;
+        }
+    };
+
+
+    template<bool has_deletions, bool collect_metrics = false>
+    std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
+    searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef,
+                      const std::list<QueryFilter> &queryFilters) const {
+        VisitedList *vl = visited_list_pool_->getFreeVisitedList();
+        vl_type *visited_array = vl->mass;
+        vl_type visited_array_tag = vl->curV;
+
+        std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
+        std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
+
+        dist_t lowerBound;
+        if ((!has_deletions || !isMarkedDeleted(ep_id)) && checkCondition(getExternalLabel(ep_id), queryFilters)) {
+            dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
+            lowerBound = dist;
+            top_candidates.emplace(dist, ep_id);
+            candidate_set.emplace(-dist, ep_id);
+        } else {
+            lowerBound = std::numeric_limits<dist_t>::max();
+            candidate_set.emplace(-lowerBound, ep_id);
+        }
+
+        visited_array[ep_id] = visited_array_tag;
+        bool has_filter = false;
+        while (!candidate_set.empty()) {
+            std::pair<dist_t, tableint> current_node_pair = candidate_set.top();
+
+            if ((-current_node_pair.first) > lowerBound &&
+                (top_candidates.size() == ef || (has_deletions == false && !has_filter))) {
+                break;
+            }
+            candidate_set.pop();
+
+            tableint current_node_id = current_node_pair.second;
+            int *data = (int *) get_linklist0(current_node_id);
+            size_t size = getListCount((linklistsizeint *) data);
+//                bool cur_node_deleted = isMarkedDeleted(current_node_id);
+            if (collect_metrics) {
+                metric_hops++;
+                metric_distance_computations += size;
+            }
+
+#ifdef USE_SSE
+            _mm_prefetch((char *) (visited_array + *(data + 1)), _MM_HINT_T0);
+            _mm_prefetch((char *) (visited_array + *(data + 1) + 64), _MM_HINT_T0);
+            _mm_prefetch(data_level0_memory_ + (*(data + 1)) * size_data_per_element_ + offsetData_, _MM_HINT_T0);
+            _mm_prefetch((char *) (data + 2), _MM_HINT_T0);
+#endif
+
+            for (size_t j = 1; j <= size; j++) {
+                int candidate_id = *(data + j);
+#ifdef USE_SSE
+                _mm_prefetch((char *) (visited_array + *(data + j + 1)), _MM_HINT_T0);
+                _mm_prefetch(data_level0_memory_ + (*(data + j + 1)) * size_data_per_element_ + offsetData_,
+                             _MM_HINT_T0);////////////
+#endif
+                if (!(visited_array[candidate_id] == visited_array_tag)) {
+
+                    visited_array[candidate_id] = visited_array_tag;
+
+                    char *currObj1 = (getDataByInternalId(candidate_id));
+                    dist_t dist = fstdistfunc_(data_point, currObj1, dist_func_param_);
+
+                    if (top_candidates.size() < ef || lowerBound > dist) {
+                        candidate_set.emplace(-dist, candidate_id);
+#ifdef USE_SSE
+                        _mm_prefetch(data_level0_memory_ + candidate_set.top().second * size_data_per_element_ +
+                                     offsetLevel0_,///////////
+                                     _MM_HINT_T0);////////////////////////
+#endif
+
+                        if (!has_deletions || !isMarkedDeleted(candidate_id)) {
+                            if (checkCondition(getExternalLabel(candidate_id), queryFilters)) {
+                                top_candidates.emplace(dist, candidate_id);
+                            } else {
+                                has_filter = true;
+                            }
+                        }
+
+                        if (top_candidates.size() > ef) {
+                            top_candidates.pop();
+                        }
+
+                        if (!top_candidates.empty())
+                            lowerBound = top_candidates.top().first;
+                    }
+                }
+            }
+        }
+
+        visited_list_pool_->releaseVisitedList(vl);
+        return top_candidates;
+    }
+
+
+    // saveIndex
+    void saveIndex(const std::string &dir) {
+        // if not exist, then create
+        if (nullptr == opendir(dir.c_str())) {
+            mkdir(dir.c_str(), 0755);
+        }
+        std::string vec_index_path = dir + "/" + INDEX_NAME_VEC;
+        std::string tag_index_path = dir + "/" + INDEX_NAME_TAG;
+
+        HierarchicalNSW<dist_t>::saveIndex(vec_index_path);
+
+        std::ofstream output(tag_index_path, std::ios::binary);
+        int map_size = tag_index_dict.size();
+        writeBinaryPOD(output, map_size);
+
+        for (auto &tag_index : tag_index_dict) {
+            TagIndex::writeString(output, tag_index.first);
+            tag_index.second.serialize(output);
+        }
+        output.close();
+    }
+
+
+    // loadIndex
+    void loadIndex(const std::string &dir, SpaceInterface <dist_t> *s, size_t max_elements_i = 0) {
+        std::string vec_index_path = dir + "/" + INDEX_NAME_VEC;
+        std::string tag_index_path = dir + "/" + INDEX_NAME_TAG;
+
+        HierarchicalNSW<dist_t>::loadIndex(vec_index_path, s, max_elements_i);
+
+        std::ifstream input(tag_index_path, std::ios::binary);
+        int map_size = 0;
+        readBinaryPOD(input, map_size);
+
+        for (int i = 0; i < map_size; i++) {
+            std::string name = TagIndex::readString(input);
+            TagIndex &tag_index = tag_index_dict[name];
+            tag_index.name = name;
+            tag_index.deserialize(input);
+        }
+        input.close();
+    }
+
+};
+
+
+
+} // namespace hnswlib
+
+#endif  // _HNSWPF_CORE_H_
+/* vim: set ts=4 sw=4 sts=4 tw=100 */
+
+

--- a/hnswpf/hnsw_query.h
+++ b/hnswpf/hnsw_query.h
@@ -1,0 +1,57 @@
+
+#ifndef HNSWPF_QUERY_H_
+#define HNSWPF_QUERY_H_
+
+
+namespace hnswlib {
+
+
+class QueryFilter {
+public:
+    QueryFilter() : name("ID") { }
+    QueryFilter(std::string &n) : name(n) {}
+
+    /**
+     * add a tag search
+     * @param required, true need, false discard
+     * @param id ID
+     * @return
+     */
+    int add(int id, bool required) {
+        if (required) {
+            includes.insert(id);
+        }
+        if(!required){
+            excludes.insert(id);
+        }
+        return 0;
+    }
+
+public:
+    std::string name;
+
+    std::unordered_set<int> includes;
+    std::unordered_set<int> excludes;
+};
+
+
+class QueryFilterList {
+public:
+    QueryFilterList() { };
+
+    int add(QueryFilter* queryFilter) {
+        filters.push_back(*queryFilter);
+        return 0;
+    }
+    std::list<QueryFilter> filters;
+};
+
+
+} // namespace hnswlib
+
+#endif // _HNSWPF_QUERY_H_
+/* vim: set ts=4 sw=4 sts=4 tw=100 */
+
+
+
+

--- a/hnswpf/hnsw_tags.h
+++ b/hnswpf/hnsw_tags.h
@@ -1,0 +1,152 @@
+#ifndef _HNSWPF_TAG_H_
+#define _HNSWPF_TAG_H_
+
+#include <mutex>
+#include <cstring>
+#include <utility>
+#include <vector>
+#include <set>
+#include <sstream>
+#include <unordered_set>
+
+
+namespace hnswlib {
+
+
+
+class TagIndex {
+public:
+    static const int max_tag_locks = 8192;
+
+    std::vector<std::mutex> tag_lock;
+
+    // tag filed name
+    std::string name;
+
+    // tag -> docId set
+    std::unordered_map<int, std::unordered_set<int>> tag_to_externals;
+
+public:
+    TagIndex() : name(""), tag_lock(max_tag_locks) {}
+
+    std::unordered_set<int> getExternals(int item) const {
+        std::unordered_set<int> externals;
+
+        auto find_externals = tag_to_externals.find(item);
+        if (find_externals != tag_to_externals.end())
+            return find_externals->second;
+        return externals;
+    }
+
+    void insert(int tag, int external_id) {
+        std::unique_lock<std::mutex> tl(tag_lock[tag & (max_tag_locks - 1)]);
+        const auto &iter = tag_to_externals.find(tag);
+        // field tag exists
+        if (iter != tag_to_externals.end()) {
+            tag_to_externals[tag].insert(external_id);
+        } else {
+            tag_to_externals[tag] = {external_id};
+        }
+    }
+
+
+    void serialize(std::ostream &out) {
+        writeString(out, name);
+        writeSetMap(out, tag_to_externals);
+    }
+
+    void deserialize(std::istream &in) {
+        name = readString(in);
+        tag_to_externals = readSetMap(in);
+    }
+
+
+    static void writeSetMap(std::ostream &out,
+                            const std::unordered_map<int, std::unordered_set<int>> &map) {
+        int item_size = (int)map.size();
+        writeBinaryPOD(out, item_size);
+        for (const auto &pair : map) {
+            writeBinaryPOD(out, pair.first);
+
+            int id_size = (int)pair.second.size();
+            writeBinaryPOD(out, id_size);
+            // std::unordered_set<int>
+            for (int iter : pair.second) {
+                writeBinaryPOD(out, iter);
+            }
+        }
+    }
+
+    static void writeIntMap(std::ostream &out, const std::unordered_map<int, int>& map) {
+        int item_size = (int)map.size();
+        writeBinaryPOD(out, item_size);
+        for (const auto &pair : map) {
+            writeBinaryPOD(out, pair.first);
+            // int
+            writeBinaryPOD(out, pair.second);
+        }
+    }
+
+    static std::unordered_map<int, std::unordered_set<int>> readSetMap(std::istream &in) {
+        std::unordered_map<int, std::unordered_set<int>> map;
+
+        int item_size;
+        readBinaryPOD(in, item_size);
+        for (int i = 0; i < item_size; i++) {
+            int element;
+            readBinaryPOD(in, element);
+            int externals_length;
+            readBinaryPOD(in, externals_length);
+
+            std::unordered_set<int> _externals;
+            for (int j = 0; j < externals_length; j++) {
+                int id;
+                readBinaryPOD(in, id);
+                _externals.emplace(id);
+            }
+            map.emplace(element, _externals);
+        }
+        return map;
+    }
+
+    static std::unordered_map<int, int> readIntMap(std::istream &in) {
+        std::unordered_map<int, int> map;
+
+        int item_size;
+        readBinaryPOD(in, item_size);
+        for (int i = 0; i < item_size; i++) {
+            int tag;
+            readBinaryPOD(in, tag);
+            int val;
+            readBinaryPOD(in, val);
+            map.emplace(tag, val);
+        }
+        return map;
+    }
+
+    static void writeString(std::ostream &out, std::string podRef) {
+        int size = podRef.size();
+        out.write((char *) &size, sizeof(size));
+        out.write(&podRef[0], size);
+    }
+
+    static std::string readString(std::istream &in) {
+        std::string str;
+        int size;
+        in.read((char *) &size, sizeof(size));
+
+        str.resize(size);
+        in.read(&str[0], size);
+        return str;
+    }
+
+};
+
+
+} // namespace hnswlib
+
+#endif  // _HNSWPF_TAG_H_
+/* vim: set ts=4 sw=4 sts=4 tw=100 */
+
+
+

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -3,6 +3,8 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 #include "hnswlib.h"
+#include "hnsw_query.h"
+#include "hnsw_core.h"
 #include <thread>
 #include <atomic>
 #include <stdlib.h>
@@ -835,6 +837,252 @@ public:
 
 };
 
+class QueryFilter {
+public:
+    hnswlib::QueryFilter *queryFilter;
+
+    QueryFilter(std::string tagName) {
+        this->queryFilter = new hnswlib::QueryFilter(tagName);
+    }
+
+    int add(int id, bool required) {
+        return queryFilter->add(id, required);
+    }
+
+    ~QueryFilter() {
+        delete queryFilter;
+    }
+};
+
+class QueryFilterList {
+public:
+    hnswlib::QueryFilterList *queryFilterList;
+
+    QueryFilterList() {
+        queryFilterList = new hnswlib::QueryFilterList();
+    }
+
+    int add(QueryFilter &filter) {
+        queryFilterList->add(filter.queryFilter);
+    }
+
+    ~QueryFilterList() {
+        delete queryFilterList;
+    }
+};
+
+template<typename dist_t, typename data_t=float>
+class PFIndex {
+public:
+    PFIndex(const std::string &space_name, const int dim) :
+            space_name(space_name), dim(dim) {
+        normalize = false;
+        if (space_name == "l2") {
+            space = new hnswlib::L2Space(dim);
+        } else if (space_name == "ip") {
+            space = new hnswlib::InnerProductSpace(dim);
+        } else if (space_name == "cosine") {
+            space = new hnswlib::InnerProductSpace(dim);
+            normalize = true;
+        } else {
+            throw std::runtime_error("Space name must be one of l2, ip, or cosine.");
+        }
+        alg = NULL;
+        index_inited = false;
+    }
+
+    static const int ser_version = 1; // serialization version
+
+    std::string space_name;
+    int dim;
+    bool index_inited;
+    bool normalize;
+
+    hnswlib::labeltype cur_l;
+    hnswlib::SearchHNSW <dist_t> *alg;
+    hnswlib::SpaceInterface<float> *space;
+
+    ~PFIndex() {
+        delete space;
+        if (alg)
+            delete alg;
+    }
+
+
+    void initIndex(const size_t maxElements, const size_t M, const size_t ef) {
+        if (alg) {
+            throw std::runtime_error("The index is already initiated.");
+        }
+        cur_l = 0;
+        alg = new hnswlib::SearchHNSW<dist_t>(space, maxElements, M, ef);
+        index_inited = true;
+    }
+
+    void normalize_vector(float *data, float *norm_array) {
+        float norm = 0.0f;
+        for (int i = 0; i < dim; i++)
+            norm += data[i] * data[i];
+        norm = 1.0f / (sqrtf(norm) + 1e-30f);
+        for (int i = 0; i < dim; i++)
+            norm_array[i] = data[i] * norm;
+    }
+
+    void add(py::object input, py::object ids_ = py::none()) {
+        py::array_t < dist_t, py::array::c_style | py::array::forcecast > items(input);
+        auto buffer = items.request();
+        size_t rows, features;
+
+        if (buffer.ndim != 2 && buffer.ndim != 1) throw std::runtime_error("data must be a 1d/2d array");
+        if (buffer.ndim == 2) {
+            rows = buffer.shape[0];
+            features = buffer.shape[1];
+        } else {
+            rows = 1;
+            features = buffer.shape[0];
+        }
+
+        if (features != dim)
+            throw std::runtime_error("wrong dimensionality of the vectors");
+
+        std::vector<size_t> ids;
+
+        if (!ids_.is_none()) {
+            py::array_t < size_t, py::array::c_style | py::array::forcecast > items(ids_);
+            auto ids_numpy = items.request();
+            if (ids_numpy.ndim == 1 && ids_numpy.shape[0] == rows) {
+                std::vector<size_t> ids1(ids_numpy.shape[0]);
+                for (size_t i = 0; i < ids1.size(); i++) {
+                    ids1[i] = items.data()[i];
+                }
+                ids.swap(ids1);
+            } else if (ids_numpy.ndim == 0 && rows == 1) {
+                ids.push_back(*items.data());
+            } else
+                throw std::runtime_error("wrong dimensionality of the labels");
+        }
+        {
+
+            for (size_t row = 0; row < rows; row++) {
+                size_t id = ids.size() ? ids.at(row) : cur_l + row;
+                if (!normalize) {
+                    alg->addPoint((void *) items.data(row), (size_t) id);
+                } else {
+                    std::vector<float> normalized_vector(dim);
+                    normalize_vector((float *) items.data(row), normalized_vector.data());
+                    alg->addPoint((void *) normalized_vector.data(), (size_t) id);
+                }
+            }
+            cur_l += rows;
+        }
+    }
+
+
+    int addFieldTag(long key, const std::string &field, int tag) {
+        alg->addFieldTag(key, field, tag);
+        return 0;
+    }
+
+    void markDelete(size_t label) {
+        alg->markDelete(label);
+    }
+
+    void saveIndex(const std::string &dir) {
+        alg->saveIndex(dir);
+    }
+
+    void loadIndex(const std::string &dir, const size_t maxElements) {
+        if (alg) {
+            std::cerr << "Warning: Calling load_index for an already inited index. Old index is being deallocated."
+                      << std::endl;
+            delete alg;
+        }
+        alg = new hnswlib::SearchHNSW<dist_t>(space, maxElements);
+        alg->loadIndex(dir, space, maxElements);
+        cur_l = alg->cur_element_count;
+        index_inited = true;
+    }
+
+
+    py::object knnQuery(py::object input, size_t k = 1, const QueryFilterList &filters = {}) {
+
+        py::array_t < dist_t, py::array::c_style | py::array::forcecast > items(input);
+        auto buffer = items.request();
+        hnswlib::labeltype *data_numpy_l;
+        dist_t *data_numpy_d;
+        size_t rows, features;
+        {
+            py::gil_scoped_release l;
+
+            if (buffer.ndim != 2 && buffer.ndim != 1) throw std::runtime_error("data must be a 1d/2d array");
+            if (buffer.ndim == 2) {
+                rows = buffer.shape[0];
+                features = buffer.shape[1];
+            } else {
+                rows = 1;
+                features = buffer.shape[0];
+            }
+
+            data_numpy_l = new hnswlib::labeltype[rows * k];
+            data_numpy_d = new dist_t[rows * k];
+
+            std::list<hnswlib::QueryFilter> queryFilters = ((hnswlib::QueryFilterList *) filters.queryFilterList)->filters;
+            for (size_t row = 0; row < rows; row++) {
+
+                if (normalize == false) {
+                    std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result = alg->searchKnn(
+                            (void *) items.data(row), k, queryFilters);
+                    if (result.size() < k) {
+                        k = result.size();
+                    }
+                    for (int i = result.size() - 1; i >= 0; i--) {
+                        auto &result_tuple = result.top();
+                        data_numpy_d[row * k + i] = result_tuple.first;
+                        data_numpy_l[row * k + i] = result_tuple.second;
+                        result.pop();
+                    }
+                } else {
+                    std::vector<float> normalized_vector(dim);
+                    normalize_vector((float *) items.data(row), normalized_vector.data());
+                    std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result = alg->searchKnn(
+                            (void *) normalized_vector.data(), k, queryFilters);
+                    if (result.size() < k) {
+                        k = result.size();
+                    }
+                    for (int i = result.size() - 1; i >= 0; i--) {
+                        auto &result_tuple = result.top();
+                        data_numpy_d[row * k + i] = result_tuple.first;
+                        data_numpy_l[row * k + i] = result_tuple.second;
+                        result.pop();
+                    }
+                }
+            }
+        }
+
+        py::capsule free_when_done_l(data_numpy_l, [](void *f) {
+            delete[] f;
+        });
+        py::capsule free_when_done_d(data_numpy_d, [](void *f) {
+            delete[] f;
+        });
+
+
+        return py::make_tuple(
+                py::array_t<hnswlib::labeltype>(
+                        {rows, k}, // shape
+                        {k * sizeof(hnswlib::labeltype),
+                         sizeof(hnswlib::labeltype)}, // C-style contiguous strides for double
+                        data_numpy_l, // the data pointer
+                        free_when_done_l),
+                py::array_t<dist_t>(
+                        {rows, k}, // shape
+                        {k * sizeof(dist_t), sizeof(dist_t)}, // C-style contiguous strides for double
+                        data_numpy_d, // the data pointer
+                        free_when_done_d));
+
+    }
+
+};
+
 PYBIND11_PLUGIN(hnswlib) {
         py::module m("hnswlib");
 
@@ -908,6 +1156,36 @@ PYBIND11_PLUGIN(hnswlib) {
         .def("load_index", &BFIndex<float>::loadIndex, py::arg("path_to_index"), py::arg("max_elements")=0)
         .def("__repr__", [](const BFIndex<float> &a) {
             return "<hnswlib.BFIndex(space='" + a.space_name + "', dim="+std::to_string(a.dim)+")>";
+        });
+
+
+
+        py::class_<PFIndex<float>>(m, "PFIndex")
+        .def(py::init<const std::string &, const int>(), py::arg("space"), py::arg("dim"))
+        .def("init_index", &PFIndex<float>::initIndex, py::arg("max_elements"), py::arg("M"), py::arg("ef"))
+        .def("knn_query", &PFIndex<float>::knnQuery, py::arg("data"), py::arg("k")=1, py::arg("query_list"))
+        .def("add", &PFIndex<float>::add, py::arg("data"), py::arg("ids") = py::none())
+        .def("add_field_tag", &PFIndex<float>::addFieldTag, py::arg("key"), py::arg("field"), py::arg("tag"))
+        .def("mark_delete", &PFIndex<float>::markDelete, py::arg("label"))
+        .def("save_index", &PFIndex<float>::saveIndex, py::arg("dir"))
+        .def("load_index", &PFIndex<float>::loadIndex, py::arg("dir"), py::arg("max_elements")=0)
+        .def("__repr__",[](const PFIndex<float> &a) {
+            return "<hnswlib.PFIndex(space='" + a.space_name + "', dim=" + std::to_string(a.dim) + ")>";
+        });
+
+        py::class_<QueryFilter>(m, "QueryFilter")
+        .def(py::init<const std::string &>(), py::arg("tag_name"))
+        .def("add", &QueryFilter::add, py::arg("id"), py::arg("required"))
+        .def("__repr__",[](const QueryFilter &a) {
+            return "<hnswlib.QueryFilter(tagName='" + a.queryFilter->name + ")>";
+        });
+
+
+        py::class_<QueryFilterList>(m, "QueryFilterList")
+        .def(py::init<>())
+        .def("add", &QueryFilterList::add, py::arg("filter"))
+        .def("__repr__",[](const QueryFilterList &a) {
+            return "<hnswlib.QueryFilterList()>";
         });
         return m.ptr();
 }

--- a/python_bindings/tests/bindings_test_tag.py
+++ b/python_bindings/tests/bindings_test_tag.py
@@ -1,0 +1,175 @@
+import shutil
+import unittest
+
+import numpy as np
+
+import hnswlib
+
+
+def get_data():
+    data1 = np.asarray([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 1],
+        [1, 1, 1],
+    ])
+    return data1
+
+
+def get_tag():
+    tags1 = [1, 1, 0, 0, 0]
+    tags2 = [1, 0, 0, 0, 1]
+    return tags1, tags2
+
+
+def test_no_tag(self):
+    # result in order [[4 3 0 1 2]]
+    data1 = get_data()
+    for space, expected_distances in [
+        ('l2', [[0., 1., 2., 2., 2.]]),
+        ('ip', [[-2., -1., 0., 0., 0.]]),
+        ('cosine', [[0, 1.835e-01, 4.23e-01, 4.23e-01, 4.23e-01]])]:
+        data2 = np.concatenate([np.zeros([data1.shape[0], 5]), data1, np.zeros([data1.shape[0], 5])], axis=1)
+
+        p = hnswlib.PFIndex(space=space, dim=data2.shape[1])
+        p.init_index(max_elements=5, ef=100, M=16)
+        p.add(data2)
+
+        # test space
+        filterList = hnswlib.QueryFilterList()
+        labels, distances = p.knn_query(data=np.asarray(data2[-1:]), k=5, query_list=filterList)
+        diff = np.mean(np.abs(distances - expected_distances))
+        self.assertAlmostEqual(diff, 0, delta=1e-3)
+
+
+def test_tag_true(self):
+    # result in order [[0 1]]
+    data1 = get_data()
+    tag1, tag2 = get_tag()
+
+    data2 = np.concatenate([np.zeros([data1.shape[0], 5]), data1, np.zeros([data1.shape[0], 5])], axis=1)
+
+    p = hnswlib.PFIndex(space="ip", dim=data2.shape[1])
+    p.init_index(max_elements=5, ef=100, M=16)
+    p.add(data2)
+
+    for id, tag in enumerate(tag1):
+        p.add_field_tag(id, "tag1", tag)
+
+    for id, tag in enumerate(tag2):
+        p.add_field_tag(id, "tag2", tag)
+
+    # filter tag1 = 1 -> [[0, 1]]
+    filterList = hnswlib.QueryFilterList()
+    queryFilter = hnswlib.QueryFilter("tag1")
+    queryFilter.add(1, True)
+    filterList.add(queryFilter)
+
+    labels, distances = p.knn_query(data=np.asarray(data2[-1:]), k=5, query_list=filterList)
+    diff = np.mean(np.abs(distances - [[0., 0.]]))
+    self.assertAlmostEqual(diff, 0, delta=1e-3)
+
+    # filter id = 1 -> [[0]]
+    idFilter = hnswlib.QueryFilter("ID")
+    idFilter.add(1, False)
+    # &
+    filterList.add(idFilter)
+
+    labels, distances = p.knn_query(data=np.asarray(data2[-1:]), k=5, query_list=filterList)
+    diff = np.mean(np.abs(distances - [[0.]]))
+    self.assertAlmostEqual(diff, 0, delta=1e-3)
+
+
+def test_tag_false(self):
+    # result in order [[0,1]]
+    data1 = get_data()
+    tag1, tag2 = get_tag()
+    expected_distances = [[-2., -1., 0.]]
+
+    data2 = np.concatenate([np.zeros([data1.shape[0], 5]), data1, np.zeros([data1.shape[0], 5])], axis=1)
+    dim = data2.shape[1]
+    p = hnswlib.PFIndex(space="ip", dim=dim)
+    p.init_index(max_elements=5, ef=100, M=16)
+    p.add(data2)
+
+    for id, tag in enumerate(tag1):
+        p.add_field_tag(id, "tag1", tag)
+
+    for id, tag in enumerate(tag2):
+        p.add_field_tag(id, "tag2", tag)
+
+    # filter tag1 = 1
+    filterList = hnswlib.QueryFilterList()
+    queryFilter = hnswlib.QueryFilter("tag1")
+    queryFilter.add(1, False)
+    filterList.add(queryFilter)
+
+    labels, distances = p.knn_query(data=np.asarray(data2[-1:]), k=5, query_list=filterList)
+    diff = np.mean(np.abs(distances - expected_distances))
+    self.assertAlmostEqual(diff, 0, delta=1e-3)
+
+
+def test_save_load(self, dir):
+    # result in order [[4 3 2]]
+    data1 = get_data()
+    tag1, tag2 = get_tag()
+
+    data2 = np.concatenate([np.zeros([data1.shape[0], 5]), data1, np.zeros([data1.shape[0], 5])], axis=1)
+    p = hnswlib.PFIndex(space="ip", dim=data2.shape[1])
+    p.init_index(max_elements=5, ef=100, M=16)
+    p.add(data2)
+    for id, tag in enumerate(tag1):
+        p.add_field_tag(id, "tag1", tag)
+    for id, tag in enumerate(tag2):
+        p.add_field_tag(id, "tag2", tag)
+
+    # filter tag1 = 1
+    expected_distances = [[0., 0.]]
+    filterList = hnswlib.QueryFilterList()
+    queryFilter = hnswlib.QueryFilter("tag1")
+    queryFilter.add(1, True)
+    filterList.add(queryFilter)
+
+    labels, distances = p.knn_query(data=np.asarray(data2[-1:]), k=5, query_list=filterList)
+    diff = np.mean(np.abs(distances - expected_distances))
+    self.assertAlmostEqual(diff, 0, delta=1e-3)
+
+    print("TAG saving index to '%s' ..." % dir)
+    p.save_index(dir)
+    del p
+
+    p = hnswlib.PFIndex(space='ip', dim=data2.shape[1])  # you can change the sa
+    print("TAG loading index from '%s'" % dir)
+    p.load_index(dir, max_elements=5)
+    # filter tag1 = 1
+    expected_distances = [[0., 0.]]
+    filterList = hnswlib.QueryFilterList()
+    queryFilter = hnswlib.QueryFilter("tag1")
+    queryFilter.add(1, True)
+    filterList.add(queryFilter)
+
+    labels, distances = p.knn_query(data=np.asarray(data2[-1:]), k=5, query_list=filterList)
+    diff = np.mean(np.abs(distances - expected_distances))
+    self.assertAlmostEqual(diff, 0, delta=1e-3)
+
+    shutil.rmtree(dir)
+
+
+class RandomSelfTestCase(unittest.TestCase):
+    def testRandomSelf(self):
+        # 1、test_space
+        test_no_tag(self)
+        print("TAG test_no_tag succuss")
+
+        # 2、test_tag_true
+        test_tag_true(self)
+        print("TAG test_tag_true succuss")
+
+        # 3、test_tag_false
+        test_tag_false(self)
+        print("TAG test_tag_false succuss")
+
+        # 4、test_save_load
+        test_save_load(self, "tag_idx")
+        print("TAG test succuss")

--- a/python_bindings/tests/bindings_test_tag.py
+++ b/python_bindings/tests/bindings_test_tag.py
@@ -155,7 +155,7 @@ def test_save_load(self, dir):
 
 
 class TagTestCase(unittest.TestCase):
-    def testSelf(self):
+    def runCase(self):
         # 1、test_space
         test_no_tag(self)
         print("TAG test_no_tag succuss")

--- a/python_bindings/tests/bindings_test_tag.py
+++ b/python_bindings/tests/bindings_test_tag.py
@@ -1,4 +1,3 @@
-import shutil
 import unittest
 
 import numpy as np
@@ -153,11 +152,10 @@ def test_save_load(self, dir):
     diff = np.mean(np.abs(distances - expected_distances))
     self.assertAlmostEqual(diff, 0, delta=1e-3)
 
-    shutil.rmtree(dir)
 
 
-class RandomSelfTestCase(unittest.TestCase):
-    def testRandomSelf(self):
+class TagTestCase(unittest.TestCase):
+    def testSelf(self):
         # 1、test_space
         test_no_tag(self)
         print("TAG test_no_tag succuss")

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ include_dirs = [
 bindings_dir = 'python_bindings'
 if bindings_dir in os.path.basename(os.getcwd()):
     source_files = ['./bindings.cpp']
-    include_dirs.extend(['../hnswlib/'])
+    include_dirs.extend(['../hnswlib/','../hnswpf/'])
 else:
     source_files = ['./python_bindings/bindings.cpp']
-    include_dirs.extend(['./hnswlib/'])
+    include_dirs.extend(['./hnswlib/','./hnswpf/'])
 
 
 libraries = []


### PR DESCRIPTION
I notice the issue（Support "skipping" nodes during traversal? #294） and support it , further supports tag search～

1、when building the index , enable to define the tag of the vector 
2、when the build is finished，add a inverted file to store those tags 
3、when querying,  use the inverted file to skip nodes by tag (or id)
4、add a python file to test 