### PR TITLE
Python recall test update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,15 @@ name: HNSW CI
 on: [push, pull_request]
 
 jobs:
-  test:
+  test_python:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           
@@ -20,3 +20,31 @@ jobs:
       
       - name: Test
         run: python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py"
+  
+  test_cpp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+
+      - name: Prepare test data
+        run: |
+          pip install numpy
+          cd examples
+          python update_gen_data.py
+      
+      - name: Test
+        run: |
+          cd build
+          ./searchKnnCloserFirst_test
+          ./test_updates
+          ./test_updates update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
             cp ./Release/* ./
           fi
           ./searchKnnCloserFirst_test
+          ./searchKnnWithFilter_test
           ./test_updates
           ./test_updates update
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
         run: python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py"
   
   test_cpp:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -34,17 +37,27 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          make
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            make
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            cmake --build ./ --config Release
+          fi
+        shell: bash
 
       - name: Prepare test data
         run: |
           pip install numpy
           cd examples
           python update_gen_data.py
+        shell: bash
       
       - name: Test
         run: |
           cd build
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            cp ./Release/* ./
+          fi
           ./searchKnnCloserFirst_test
           ./test_updates
           ./test_updates update
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         run: python -m pip install .
       
       - name: Test
-        run: python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py"
+        run: python -m unittest discover -v --start-directory python_bindings/tests --pattern "*_test*.py"
   
   test_cpp:
     runs-on: ${{matrix.os}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_executable(searchKnnCloserFirst_test examples/searchKnnCloserFirst_test.cpp)
     target_link_libraries(searchKnnCloserFirst_test hnswlib)
 
+    add_executable(searchKnnWithFilter_test examples/searchKnnWithFilter_test.cpp)
+    target_link_libraries(searchKnnWithFilter_test hnswlib)
+
     add_executable(main main.cpp sift_1b.cpp)
     target_link_libraries(main hnswlib)
 endif()

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ https://github.com/dbaranchuk/ivf-hnsw
 * Java bindings using Java Native Access: https://github.com/stepstone-tech/hnswlib-jna
 * .Net implementation: https://github.com/microsoft/HNSW.Net
 * CUDA implementation: https://github.com/js1010/cuhnsw
-
+* Rust implementation for memory and thread safety purposes and There is  A Trait to enable the user to implement its own distances. It takes as data slices of types T satisfying T:Serialize+Clone+Send+Sync.: https://github.com/jean-pierreBoth/hnswlib-rs
 
 ### 200M SIFT test reproduction 
 To download and extract the bigann dataset (from root directory):

--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ To run test **with** updates (from `build` directory)
 - Visual search engine for 1M amazon products (MXNet + HNSW): [website](https://thomasdelteil.github.io/VisualSearch_MXNet/), [code](https://github.com/ThomasDelteil/VisualSearch_MXNet), demo by [@ThomasDelteil](https://github.com/ThomasDelteil)
 
 ### References
-
+HNSW paper:
+```
 @article{malkov2018efficient,
   title={Efficient and robust approximate nearest neighbor search using hierarchical navigable small world graphs},
   author={Malkov, Yu A and Yashunin, Dmitry A},
@@ -328,3 +329,6 @@ To run test **with** updates (from `build` directory)
   year={2018},
   publisher={IEEE}
 }
+```
+
+The update algorithm supported in this repository is to be published in "Dynamic Updates For HNSW, Hierarchical Navigable Small World Graphs" US Patent 15/929,802 by Apoorv Sharma, Abhishek Tayal and Yury Malkov.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Please make pull requests against the `develop` branch.
 
 When making changes please run tests (and please add a test to `python_bindings/tests` in case there is new functionality):
 ```bash
-python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py
+python -m unittest discover --start-directory python_bindings/tests --pattern "*_test*.py"
 ```
 
 

--- a/TESTING_RECALL.md
+++ b/TESTING_RECALL.md
@@ -27,7 +27,7 @@ max_elements defines the maximum number of elements that can be stored in the st
 
 ### measuring recall example
 
-```
+```python
 import hnswlib
 import numpy as np
 

--- a/examples/git_tester.py
+++ b/examples/git_tester.py
@@ -11,8 +11,8 @@ else:
     rm_dir_cmd = "rm -rf"
 
 speedtest_src_path = os.path.join("examples", "speedtest.py")
-speedtest_path = os.path.join("examples", "speedtest2.py")
-os.system(f"{copy_cmd} {speedtest_src_path} {speedtest_path}")  # the file has to be outside of git
+speedtest_copy_path = os.path.join("examples", "speedtest2.py")
+os.system(f"{copy_cmd} {speedtest_src_path} {speedtest_copy_path}")  # the file has to be outside of git
 
 commits = list(Repository('.', from_tag="v0.6.0").traverse_commits())
 print("Found commits:")
@@ -37,8 +37,8 @@ for commit in commits:
         print("build failed!!!!")
         continue
 
-    os.system(f'python {speedtest_path} -n "{name}" -d 4 -t 1')
-    os.system(f'python {speedtest_path} -n "{name}" -d 64 -t 1')
-    os.system(f'python {speedtest_path} -n "{name}" -d 128 -t 1')
-    os.system(f'python {speedtest_path} -n "{name}" -d 4 -t 24')
-    os.system(f'python {speedtest_path} -n "{name}" -d 128 -t 24')
+    os.system(f'python {speedtest_copy_path} -n "{name}" -d 4 -t 1')
+    os.system(f'python {speedtest_copy_path} -n "{name}" -d 64 -t 1')
+    os.system(f'python {speedtest_copy_path} -n "{name}" -d 128 -t 1')
+    os.system(f'python {speedtest_copy_path} -n "{name}" -d 4 -t 24')
+    os.system(f'python {speedtest_copy_path} -n "{name}" -d 128 -t 24')

--- a/examples/git_tester.py
+++ b/examples/git_tester.py
@@ -1,18 +1,13 @@
 import os
+import shutil
 
 from sys import platform
 from pydriller import Repository
 
-if platform == "win32":
-    copy_cmd = "copy"
-    rm_dir_cmd = "rmdir /s /q"
-else:
-    copy_cmd = "cp"
-    rm_dir_cmd = "rm -rf"
 
 speedtest_src_path = os.path.join("examples", "speedtest.py")
 speedtest_copy_path = os.path.join("examples", "speedtest2.py")
-os.system(f"{copy_cmd} {speedtest_src_path} {speedtest_copy_path}")  # the file has to be outside of git
+shutil.copyfile(speedtest_src_path, speedtest_copy_path) # the file has to be outside of git
 
 commits = list(Repository('.', from_tag="v0.6.0").traverse_commits())
 print("Found commits:")
@@ -24,8 +19,9 @@ for commit in commits:
     name = commit.msg.replace('\n', ' ').replace('\r', ' ')
     print("\nProcessing", commit.hash, name)
 
+    if os.path.exists("build"):
+        shutil.rmtree("build")
     os.system(f"git checkout {commit.hash}")
-    os.system(f"{rm_dir_cmd} build")
     print("\n\n--------------------\n\n")
     ret = os.system("python -m pip install .")
     print("Install result:", ret)

--- a/examples/git_tester.py
+++ b/examples/git_tester.py
@@ -1,34 +1,44 @@
+import os
+
+from sys import platform
 from pydriller import Repository
-import os 
-import datetime
-os.system("cp examples/speedtest.py examples/speedtest2.py") # the file has to be outside of git
-for idx, commit in enumerate(Repository('.', from_tag="v0.6.0").traverse_commits()):    
-    name=commit.msg.replace('\n', ' ').replace('\r', ' ')
+
+if platform == "win32":
+    copy_cmd = "copy"
+    rm_dir_cmd = "rmdir /s /q"
+else:
+    copy_cmd = "cp"
+    rm_dir_cmd = "rm -rf"
+
+speedtest_src_path = os.path.join("examples", "speedtest.py")
+speedtest_path = os.path.join("examples", "speedtest2.py")
+os.system(f"{copy_cmd} {speedtest_src_path} {speedtest_path}")  # the file has to be outside of git
+
+commits = list(Repository('.', from_tag="v0.6.0").traverse_commits())
+print("Found commits:")
+for idx, commit in enumerate(commits):
+    name = commit.msg.replace('\n', ' ').replace('\r', ' ')
     print(idx, commit.hash, name)
 
+for commit in commits:
+    name = commit.msg.replace('\n', ' ').replace('\r', ' ')
+    print("\nProcessing", commit.hash, name)
 
-
-for commit in Repository('.', from_tag="v0.6.0").traverse_commits():
-    
-    name=commit.msg.replace('\n', ' ').replace('\r', ' ')
-    print(commit.hash, name)
-    
-    os.system(f"git checkout {commit.hash}; rm -rf build; ")
+    os.system(f"git checkout {commit.hash}")
+    os.system(f"{rm_dir_cmd} build")
     print("\n\n--------------------\n\n")
-    ret=os.system("python -m pip install .")
-    print(ret)
-    
+    ret = os.system("python -m pip install .")
+    print("Install result:", ret)
+
     if ret != 0:
-        print ("build failed!!!!")
-        print ("build failed!!!!")
-        print ("build failed!!!!")
-        print ("build failed!!!!")
-        continue    
-    
-    os.system(f'python examples/speedtest2.py -n "{name}" -d 4 -t 1')
-    os.system(f'python examples/speedtest2.py -n "{name}" -d 64 -t 1')
-    os.system(f'python examples/speedtest2.py -n "{name}" -d 128 -t 1')
-    os.system(f'python examples/speedtest2.py -n "{name}" -d 4 -t 24')
-    os.system(f'python examples/speedtest2.py -n "{name}" -d 128 -t 24')
+        print("build failed!!!!")
+        print("build failed!!!!")
+        print("build failed!!!!")
+        print("build failed!!!!")
+        continue
 
-
+    os.system(f'python {speedtest_path} -n "{name}" -d 4 -t 1')
+    os.system(f'python {speedtest_path} -n "{name}" -d 64 -t 1')
+    os.system(f'python {speedtest_path} -n "{name}" -d 128 -t 1')
+    os.system(f'python {speedtest_path} -n "{name}" -d 4 -t 24')
+    os.system(f'python {speedtest_path} -n "{name}" -d 128 -t 24')

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -21,7 +21,7 @@ bool pickIdsDivisibleBySeven(unsigned int ep_id) {
 }
 
 template<typename filter_func_t>
-void test(filter_func_t filter_func, size_t div_num) {
+void test(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
     int d = 4;
     idx_t n = 100;
     idx_t nq = 10;
@@ -40,15 +40,15 @@ void test(filter_func_t filter_func, size_t div_num) {
     for (idx_t i = 0; i < nq * d; ++i) {
         query[i] = distrib(rng);
     }
-      
 
     hnswlib::L2Space space(d);
     hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float,hnswlib::FILTERFUNC>(&space, 2 * n);
     hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float,hnswlib::FILTERFUNC>(&space, 2 * n);
 
     for (size_t i = 0; i < n; ++i) {
-        alg_brute->addPoint(data.data() + d * i, i);
-        alg_hnsw->addPoint(data.data() + d * i, i);
+        // `label_id_start` is used to ensure that the returned IDs are labels and not internal IDs
+        alg_brute->addPoint(data.data() + d * i, label_id_start + i);
+        alg_hnsw->addPoint(data.data() + d * i, label_id_start + i);
     }
 
     // test searchKnnCloserFirst of BruteforceSearch with filtering
@@ -87,8 +87,8 @@ void test(filter_func_t filter_func, size_t div_num) {
 
 int main() {
     std::cout << "Testing ..." << std::endl;
-    test(pickIdsDivisibleByThree, 3);
-    test(pickIdsDivisibleBySeven, 7);
+    test(pickIdsDivisibleByThree, 3, 17);
+    test(pickIdsDivisibleBySeven, 7, 17);
     std::cout << "Test ok" << std::endl;
 
     return 0;

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -12,16 +12,20 @@ namespace
 
 using idx_t = hnswlib::labeltype;
 
-bool pickIdsDivisibleByThree(unsigned int ep_id) {
-    return ep_id % 3 == 0;
+bool pickIdsDivisibleByThree(unsigned int label_id) {
+    return label_id % 3 == 0;
 }
 
-bool pickIdsDivisibleBySeven(unsigned int ep_id) {
-    return ep_id % 7 == 0;
+bool pickIdsDivisibleBySeven(unsigned int label_id) {
+    return label_id % 7 == 0;
+}
+
+bool pickNothing(unsigned int label_id) {
+    return false;
 }
 
 template<typename filter_func_t>
-void test(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
+void test_some_filtering(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
     int d = 4;
     idx_t n = 100;
     idx_t nq = 10;
@@ -83,12 +87,71 @@ void test(filter_func_t filter_func, size_t div_num, size_t label_id_start) {
     delete alg_hnsw;
 }
 
+template<typename filter_func_t>
+void test_none_filtering(filter_func_t filter_func, size_t label_id_start) {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+
+    std::vector<float> data(n * d);
+    std::vector<float> query(nq * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib;
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+    for (idx_t i = 0; i < nq * d; ++i) {
+        query[i] = distrib(rng);
+    }
+
+    hnswlib::L2Space space(d);
+    hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+    hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+
+    for (size_t i = 0; i < n; ++i) {
+        // `label_id_start` is used to ensure that the returned IDs are labels and not internal IDs
+        alg_brute->addPoint(data.data() + d * i, label_id_start + i);
+        alg_hnsw->addPoint(data.data() + d * i, label_id_start + i);
+    }
+
+    // test searchKnnCloserFirst of BruteforceSearch with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_brute->searchKnn(p, k, filter_func);
+        auto res = alg_brute->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        assert(0 == gd.size());
+    }
+
+    // test searchKnnCloserFirst of hnsw with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_hnsw->searchKnn(p, k, filter_func);
+        auto res = alg_hnsw->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        assert(0 == gd.size());
+    }
+
+    delete alg_brute;
+    delete alg_hnsw;
+}
+
 } // namespace
 
 int main() {
     std::cout << "Testing ..." << std::endl;
-    test(pickIdsDivisibleByThree, 3, 17);
-    test(pickIdsDivisibleBySeven, 7, 17);
+
+    // some of the elements are filtered
+    test_some_filtering(pickIdsDivisibleByThree, 3, 17);
+    test_some_filtering(pickIdsDivisibleBySeven, 7, 17);
+
+    // all of the elements are filtered
+    test_none_filtering(pickNothing, 17);
+
     std::cout << "Test ok" << std::endl;
 
     return 0;

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -148,7 +148,7 @@ class CustomFilterFunctor: public hnswlib::FilterFunctor {
 public:
     explicit CustomFilterFunctor(const std::unordered_set<unsigned int>& values) : allowed_values(values) {}
 
-    constexpr bool operator()(unsigned int id) const {
+    bool operator()(unsigned int id) {
         return allowed_values.count(id) != 0;
     }
 };

--- a/examples/searchKnnWithFilter_test.cpp
+++ b/examples/searchKnnWithFilter_test.cpp
@@ -1,0 +1,95 @@
+// This is a test file for testing the filtering feature
+
+#include "../hnswlib/hnswlib.h"
+
+#include <assert.h>
+
+#include <vector>
+#include <iostream>
+
+namespace
+{
+
+using idx_t = hnswlib::labeltype;
+
+bool pickIdsDivisibleByThree(unsigned int ep_id) {
+    return ep_id % 3 == 0;
+}
+
+bool pickIdsDivisibleBySeven(unsigned int ep_id) {
+    return ep_id % 7 == 0;
+}
+
+template<typename filter_func_t>
+void test(filter_func_t filter_func, size_t div_num) {
+    int d = 4;
+    idx_t n = 100;
+    idx_t nq = 10;
+    size_t k = 10;
+   
+    std::vector<float> data(n * d);
+    std::vector<float> query(nq * d);
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib;
+
+    for (idx_t i = 0; i < n * d; ++i) {
+        data[i] = distrib(rng);
+    }
+    for (idx_t i = 0; i < nq * d; ++i) {
+        query[i] = distrib(rng);
+    }
+      
+
+    hnswlib::L2Space space(d);
+    hnswlib::AlgorithmInterface<float>* alg_brute  = new hnswlib::BruteforceSearch<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+    hnswlib::AlgorithmInterface<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float,hnswlib::FILTERFUNC>(&space, 2 * n);
+
+    for (size_t i = 0; i < n; ++i) {
+        alg_brute->addPoint(data.data() + d * i, i);
+        alg_hnsw->addPoint(data.data() + d * i, i);
+    }
+
+    // test searchKnnCloserFirst of BruteforceSearch with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_brute->searchKnn(p, k, filter_func);
+        auto res = alg_brute->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        size_t t = gd.size();
+        while (!gd.empty()) {
+            assert(gd.top() == res[--t]);
+            assert((gd.top().second % div_num) == 0);
+            gd.pop();
+        }
+    }
+
+    // test searchKnnCloserFirst of hnsw with filtering
+    for (size_t j = 0; j < nq; ++j) {
+        const void* p = query.data() + j * d;
+        auto gd = alg_hnsw->searchKnn(p, k, filter_func);
+        auto res = alg_hnsw->searchKnnCloserFirst(p, k, filter_func);
+        assert(gd.size() == res.size());
+        size_t t = gd.size();
+        while (!gd.empty()) {
+            assert(gd.top() == res[--t]);
+            assert((gd.top().second % div_num) == 0);
+            gd.pop();
+        }
+    }
+    
+    delete alg_brute;
+    delete alg_hnsw;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "Testing ..." << std::endl;
+    test(pickIdsDivisibleByThree, 3);
+    test(pickIdsDivisibleBySeven, 7);
+    std::cout << "Test ok" << std::endl;
+
+    return 0;
+}

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -23,7 +23,7 @@ namespace hnswlib {
             size_per_element_ = data_size_ + sizeof(labeltype);
             data_ = (char *) malloc(maxElements * size_per_element_);
             if (data_ == nullptr)
-                std::runtime_error("Not enough memory: BruteforceSearch failed to allocate data");
+                throw std::runtime_error("Not enough memory: BruteforceSearch failed to allocate data");
             cur_element_count = 0;
         }
 
@@ -140,7 +140,7 @@ namespace hnswlib {
             size_per_element_ = data_size_ + sizeof(labeltype);
             data_ = (char *) malloc(maxelements_ * size_per_element_);
             if (data_ == nullptr)
-                std::runtime_error("Not enough memory: loadIndex failed to allocate data");
+                throw std::runtime_error("Not enough memory: loadIndex failed to allocate data");
 
             input.read(data_, maxelements_ * size_per_element_);
 

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 namespace hnswlib {
-    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    template<typename dist_t, typename filter_func_t=FilterFunctor>
     class BruteforceSearch : public AlgorithmInterface<dist_t,filter_func_t> {
     public:
         BruteforceSearch(SpaceInterface <dist_t> *s) : data_(nullptr), maxelements_(0), 
@@ -92,7 +92,7 @@ namespace hnswlib {
 
 
         std::priority_queue<std::pair<dist_t, labeltype >>
-        searchKnn(const void *query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const {
+        searchKnn(const void *query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const {
             std::priority_queue<std::pair<dist_t, labeltype >> topResults;
             if (cur_element_count == 0) return topResults;
             for (int i = 0; i < k; i++) {

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -102,7 +102,7 @@ namespace hnswlib {
                     topResults.push(std::pair<dist_t, labeltype>(dist, label));
                 }
             }
-            dist_t lastdist = topResults.top().first;
+            dist_t lastdist = topResults.empty() ? std::numeric_limits<dist_t>::max() : topResults.top().first;
             for (int i = k; i < cur_element_count; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 if (dist <= lastdist) {
@@ -112,7 +112,10 @@ namespace hnswlib {
                     }
                     if (topResults.size() > k)
                         topResults.pop();
-                    lastdist = topResults.top().first;
+
+                    if (!topResults.empty()) {
+                        lastdist = topResults.top().first;
+                    }
                 }
 
             }

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -8,10 +8,14 @@ namespace hnswlib {
     template<typename dist_t>
     class BruteforceSearch : public AlgorithmInterface<dist_t> {
     public:
-        BruteforceSearch(SpaceInterface <dist_t> *s) {
+        BruteforceSearch(SpaceInterface <dist_t> *s) : data_(nullptr), maxelements_(0), 
+        cur_element_count(0), size_per_element_(0), data_size_(0), 
+        dist_func_param_(nullptr) {
 
         }
-        BruteforceSearch(SpaceInterface<dist_t> *s, const std::string &location) {
+        BruteforceSearch(SpaceInterface<dist_t> *s, const std::string &location) : 
+        data_(nullptr), maxelements_(0), cur_element_count(0), size_per_element_(0), 
+        data_size_(0), dist_func_param_(nullptr) {
             loadIndex(location, s);
         }
 

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -93,12 +93,14 @@ namespace hnswlib {
 
         std::priority_queue<std::pair<dist_t, labeltype >>
         searchKnn(const void *query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const {
+            assert(k <= cur_element_count);
             std::priority_queue<std::pair<dist_t, labeltype >> topResults;
             if (cur_element_count == 0) return topResults;
+            bool is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
             for (int i = 0; i < k; i++) {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 labeltype label = *((labeltype*) (data_ + size_per_element_ * i + data_size_));
-                if(isIdAllowed(label)) {
+                if(is_filter_disabled || isIdAllowed(label)) {
                     topResults.push(std::pair<dist_t, labeltype>(dist, label));
                 }
             }
@@ -107,7 +109,7 @@ namespace hnswlib {
                 dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
                 if (dist <= lastdist) {
                     labeltype label = *((labeltype *) (data_ + size_per_element_ * i + data_size_));
-                    if(isIdAllowed(label)) {
+                    if(is_filter_disabled || isIdAllowed(label)) {
                         topResults.push(std::pair<dist_t, labeltype>(dist, label));
                     }
                     if (topResults.size() > k)

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <mutex>
 #include <algorithm>
+#include <assert.h>
 
 namespace hnswlib {
     template<typename dist_t, typename filter_func_t=FilterFunctor>

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -308,7 +308,6 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
                             if ((!has_deletions || !isMarkedDeleted(candidate_id)) && (is_filter_disabled || isIdAllowed(getExternalLabel(candidate_id))))
                                 top_candidates.emplace(dist, candidate_id);
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -247,7 +247,8 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
 
             dist_t lowerBound;
-            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(getExternalLabel(ep_id))) {
+            bool is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
+            if ((!has_deletions || !isMarkedDeleted(ep_id)) && (is_filter_disabled || isIdAllowed(getExternalLabel(ep_id)))) {
                 dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
                 lowerBound = dist;
                 top_candidates.emplace(dist, ep_id);
@@ -307,7 +308,8 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(getExternalLabel(candidate_id)))
+                            is_filter_disabled = std::is_same<filter_func_t, decltype(allowAllIds)>::value;
+                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && (is_filter_disabled || isIdAllowed(getExternalLabel(candidate_id))))
                                 top_candidates.emplace(dist, candidate_id);
 
                             if (top_candidates.size() > ef)

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -13,7 +13,7 @@ namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
 
-    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    template<typename dist_t, typename filter_func_t=FilterFunctor>
     class HierarchicalNSW : public AlgorithmInterface<dist_t,filter_func_t> {
     public:
         static const tableint max_update_element_locks = 65536;
@@ -238,7 +238,7 @@ namespace hnswlib {
 
         template <bool has_deletions, bool collect_metrics=false>
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
-        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef, filter_func_t isIdAllowed) const {
+        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef, filter_func_t& isIdAllowed) const {
             VisitedList *vl = visited_list_pool_->getFreeVisitedList();
             vl_type *visited_array = vl->mass;
             vl_type visited_array_tag = vl->curV;
@@ -1111,7 +1111,7 @@ namespace hnswlib {
         };
 
         std::priority_queue<std::pair<dist_t, labeltype >>
-        searchKnn(const void *query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const {
+        searchKnn(const void *query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const {
             std::priority_queue<std::pair<dist_t, labeltype >> result;
             if (cur_element_count == 0) return result;
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -247,7 +247,7 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
 
             dist_t lowerBound;
-            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(ep_id)) {
+            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(getExternalLabel(ep_id))) {
                 dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
                 lowerBound = dist;
                 top_candidates.emplace(dist, ep_id);
@@ -307,7 +307,7 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(candidate_id))
+                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(getExternalLabel(candidate_id)))
                                 top_candidates.emplace(dist, candidate_id);
 
                             if (top_candidates.size() > ef)

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -13,8 +13,8 @@ namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
 
-    template<typename dist_t>
-    class HierarchicalNSW : public AlgorithmInterface<dist_t> {
+    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    class HierarchicalNSW : public AlgorithmInterface<dist_t,filter_func_t> {
     public:
         static const tableint max_update_element_locks = 65536;
         HierarchicalNSW(SpaceInterface<dist_t> *s) {
@@ -238,7 +238,7 @@ namespace hnswlib {
 
         template <bool has_deletions, bool collect_metrics=false>
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
-        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef) const {
+        searchBaseLayerST(tableint ep_id, const void *data_point, size_t ef, filter_func_t isIdAllowed) const {
             VisitedList *vl = visited_list_pool_->getFreeVisitedList();
             vl_type *visited_array = vl->mass;
             vl_type visited_array_tag = vl->curV;
@@ -247,7 +247,7 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> candidate_set;
 
             dist_t lowerBound;
-            if (!has_deletions || !isMarkedDeleted(ep_id)) {
+            if ((!has_deletions || !isMarkedDeleted(ep_id)) && isIdAllowed(ep_id)) {
                 dist_t dist = fstdistfunc_(data_point, getDataByInternalId(ep_id), dist_func_param_);
                 lowerBound = dist;
                 top_candidates.emplace(dist, ep_id);
@@ -307,7 +307,7 @@ namespace hnswlib {
                                          _MM_HINT_T0);////////////////////////
 #endif
 
-                            if (!has_deletions || !isMarkedDeleted(candidate_id))
+                            if ((!has_deletions || !isMarkedDeleted(candidate_id)) && isIdAllowed(candidate_id))
                                 top_candidates.emplace(dist, candidate_id);
 
                             if (top_candidates.size() > ef)
@@ -1111,7 +1111,7 @@ namespace hnswlib {
         };
 
         std::priority_queue<std::pair<dist_t, labeltype >>
-        searchKnn(const void *query_data, size_t k) const {
+        searchKnn(const void *query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const {
             std::priority_queue<std::pair<dist_t, labeltype >> result;
             if (cur_element_count == 0) return result;
 
@@ -1148,11 +1148,11 @@ namespace hnswlib {
             std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
             if (num_deleted_) {
                 top_candidates=searchBaseLayerST<true,true>(
-                        currObj, query_data, std::max(ef_, k));
+                        currObj, query_data, std::max(ef_, k), isIdAllowed);
             }
             else{
                 top_candidates=searchBaseLayerST<false,true>(
-                        currObj, query_data, std::max(ef_, k));
+                        currObj, query_data, std::max(ef_, k), isIdAllowed);
             }
 
             while (top_candidates.size() > k) {

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -17,15 +17,34 @@ namespace hnswlib {
     class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     public:
         static const tableint max_update_element_locks = 65536;
-        HierarchicalNSW(SpaceInterface<dist_t> *s) {
+        HierarchicalNSW(SpaceInterface<dist_t> *s) : 
+        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
+        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
+        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
+        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
+        offsetData_(0), offsetLevel0_(0), 
+        data_level0_memory_(nullptr), 
+        linkLists_(nullptr), data_size_(0), label_offset_(0), 
+        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
+        ef_(0){
         }
 
-        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) {
+        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) :
+        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
+        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
+        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
+        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
+        offsetData_(0), offsetLevel0_(0), 
+        data_level0_memory_(nullptr), 
+        linkLists_(nullptr), data_size_(0), label_offset_(0), 
+        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
+        ef_(0) {
             loadIndex(location, s, max_elements);
         }
 
         HierarchicalNSW(SpaceInterface<dist_t> *s, size_t max_elements, size_t M = 16, size_t ef_construction = 200, size_t random_seed = 100) :
-                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements) {
+                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements),
+                metric_distance_computations(0), metric_hops(0) {
             max_elements_ = max_elements;
 
             num_deleted_ = 0;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -17,34 +17,15 @@ namespace hnswlib {
     class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     public:
         static const tableint max_update_element_locks = 65536;
-        HierarchicalNSW(SpaceInterface<dist_t> *s) : 
-        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
-        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
-        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
-        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
-        offsetData_(0), offsetLevel0_(0), 
-        data_level0_memory_(nullptr), 
-        linkLists_(nullptr), data_size_(0), label_offset_(0), 
-        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
-        ef_(0){
+        HierarchicalNSW(SpaceInterface<dist_t> *s) {
         }
 
-        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) :
-        max_elements_(0), cur_element_count(0), size_data_per_element_(0), 
-        size_links_per_element_(0), num_deleted_(0), M_(0), maxM_(0), maxM0_(0), 
-        ef_construction_(0), mult_(0.0), revSize_(0.0), maxlevel_(0), 
-        visited_list_pool_(nullptr), enterpoint_node_(0), size_links_level0_(0), 
-        offsetData_(0), offsetLevel0_(0), 
-        data_level0_memory_(nullptr), 
-        linkLists_(nullptr), data_size_(0), label_offset_(0), 
-        dist_func_param_(nullptr), metric_distance_computations(0), metric_hops(0), 
-        ef_(0) {
+        HierarchicalNSW(SpaceInterface<dist_t> *s, const std::string &location, bool nmslib = false, size_t max_elements=0) {
             loadIndex(location, s, max_elements);
         }
 
         HierarchicalNSW(SpaceInterface<dist_t> *s, size_t max_elements, size_t M = 16, size_t ef_construction = 200, size_t random_seed = 100) :
-                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements),
-                metric_distance_computations(0), metric_hops(0) {
+                link_list_locks_(max_elements), link_list_update_locks_(max_update_element_locks), element_levels_(max_elements) {
             max_elements_ = max_elements;
 
             num_deleted_ = 0;
@@ -104,22 +85,21 @@ namespace hnswlib {
             delete visited_list_pool_;
         }
 
-        size_t max_elements_;
-        size_t cur_element_count;
-        size_t size_data_per_element_;
-        size_t size_links_per_element_;
-        size_t num_deleted_;
+        size_t max_elements_{0};
+        size_t cur_element_count{0};
+        size_t size_data_per_element_{0};
+        size_t size_links_per_element_{0};
+        size_t num_deleted_{0};
+        size_t M_{0};
+        size_t maxM_{0};
+        size_t maxM0_{0};
+        size_t ef_construction_{0};
 
-        size_t M_;
-        size_t maxM_;
-        size_t maxM0_;
-        size_t ef_construction_;
-
-        double mult_, revSize_;
-        int maxlevel_;
+        double mult_{0.0}, revSize_{0.0};
+        int maxlevel_{0};
 
 
-        VisitedListPool *visited_list_pool_;
+        VisitedListPool *visited_list_pool_{nullptr};
         std::mutex cur_element_count_guard_;
 
         std::vector<std::mutex> link_list_locks_;
@@ -127,20 +107,20 @@ namespace hnswlib {
         // Locks to prevent race condition during update/insert of an element at same time.
         // Note: Locks for additions can also be used to prevent this race condition if the querying of KNN is not exposed along with update/inserts i.e multithread insert/update/query in parallel.
         std::vector<std::mutex> link_list_update_locks_;
-        tableint enterpoint_node_;
+        tableint enterpoint_node_{0};
 
-        size_t size_links_level0_;
-        size_t offsetData_, offsetLevel0_;
+        size_t size_links_level0_{0};
+        size_t offsetData_{0}, offsetLevel0_{0};
 
-        char *data_level0_memory_;
-        char **linkLists_;
+        char *data_level0_memory_{nullptr};
+        char **linkLists_{nullptr};
         std::vector<int> element_levels_;
 
-        size_t data_size_;
+        size_t data_size_{0};
 
-        size_t label_offset_;
+        size_t label_offset_{0};
         DISTFUNC<dist_t> fstdistfunc_;
-        void *dist_func_param_;
+        void *dist_func_param_{nullptr};
         std::unordered_map<labeltype, tableint> label_lookup_;
 
         std::default_random_engine level_generator_;
@@ -253,8 +233,8 @@ namespace hnswlib {
             return top_candidates;
         }
 
-        mutable std::atomic<long> metric_distance_computations;
-        mutable std::atomic<long> metric_hops;
+        mutable std::atomic<long> metric_distance_computations{0};
+        mutable std::atomic<long> metric_hops{0};
 
         template <bool has_deletions, bool collect_metrics=false>
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
@@ -523,7 +503,7 @@ namespace hnswlib {
         }
 
         std::mutex global;
-        size_t ef_;
+        size_t ef_{0};
 
         void setEf(size_t ef) {
             ef_ = ef;

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -122,7 +122,7 @@ namespace hnswlib {
         bool operator()(Args&&...) { return true; }
     };
 
-    FilterFunctor allowAllIds;
+    static FilterFunctor allowAllIds;
 
     template <typename T>
     class pairGreater {

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -116,7 +116,7 @@ static bool AVX512Capable() {
 namespace hnswlib {
     typedef size_t labeltype;
 
-    bool allowAllIds(unsigned int ep_id) {
+    static bool allowAllIds(unsigned int ep_id) {
         return true;
     }
 

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -116,9 +116,13 @@ static bool AVX512Capable() {
 namespace hnswlib {
     typedef size_t labeltype;
 
-    static bool allowAllIds(unsigned int ep_id) {
-        return true;
-    }
+    // This can be extended to store state for filtering (e.g. from a std::set)
+    struct FilterFunctor {
+        template<class...Args>
+        bool operator()(Args&&...) { return true; }
+    };
+
+    FilterFunctor allowAllIds;
 
     template <typename T>
     class pairGreater {
@@ -141,8 +145,6 @@ namespace hnswlib {
     template<typename MTYPE>
     using DISTFUNC = MTYPE(*)(const void *, const void *, const void *);
 
-    using FILTERFUNC = bool(*)(unsigned int);
-
     template<typename MTYPE>
     class SpaceInterface {
     public:
@@ -156,17 +158,17 @@ namespace hnswlib {
         virtual ~SpaceInterface() {}
     };
 
-    template<typename dist_t, typename filter_func_t=FILTERFUNC>
+    template<typename dist_t, typename filter_func_t=FilterFunctor>
     class AlgorithmInterface {
     public:
         virtual void addPoint(const void *datapoint, labeltype label)=0;
 
         virtual std::priority_queue<std::pair<dist_t, labeltype >>
-            searchKnn(const void*, size_t, filter_func_t isIdAllowed=allowAllIds) const = 0;
+            searchKnn(const void*, size_t, filter_func_t& isIdAllowed=allowAllIds) const = 0;
 
         // Return k nearest neighbor in the order of closer fist
         virtual std::vector<std::pair<dist_t, labeltype>>
-            searchKnnCloserFirst(const void* query_data, size_t k, filter_func_t isIdAllowed=allowAllIds) const;
+            searchKnnCloserFirst(const void* query_data, size_t k, filter_func_t& isIdAllowed=allowAllIds) const;
 
         virtual void saveIndex(const std::string &location)=0;
         virtual ~AlgorithmInterface(){
@@ -176,7 +178,7 @@ namespace hnswlib {
     template<typename dist_t, typename filter_func_t>
     std::vector<std::pair<dist_t, labeltype>>
     AlgorithmInterface<dist_t, filter_func_t>::searchKnnCloserFirst(const void* query_data, size_t k,
-                                                                    filter_func_t isIdAllowed) const {
+                                                                    filter_func_t& isIdAllowed) const {
         std::vector<std::pair<dist_t, labeltype>> result;
 
         // here searchKnn returns the result in the order of further first

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -16,20 +16,20 @@
 #include <intrin.h>
 #include <stdexcept>
 #include "cpu_x86.h"
-void cpu_x86::cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
+static void cpu_x86::cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
     __cpuidex(out, eax, ecx);
 }
-__int64 xgetbv(unsigned int x) {
+static __int64 xgetbv(unsigned int x) {
     return _xgetbv(x);
 }
 #else
 #include <x86intrin.h>
 #include <cpuid.h>
 #include <stdint.h>
-void cpuid(int32_t cpuInfo[4], int32_t eax, int32_t ecx) {
+static void cpuid(int32_t cpuInfo[4], int32_t eax, int32_t ecx) {
     __cpuid_count(eax, ecx, cpuInfo[0], cpuInfo[1], cpuInfo[2], cpuInfo[3]);
 }
-uint64_t xgetbv(unsigned int index) {
+static uint64_t xgetbv(unsigned int index) {
     uint32_t eax, edx;
     __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
     return ((uint64_t)edx << 32) | eax;
@@ -51,7 +51,7 @@ uint64_t xgetbv(unsigned int index) {
 // Adapted from https://github.com/Mysticial/FeatureDetector
 #define _XCR_XFEATURE_ENABLED_MASK  0
 
-bool AVXCapable() {
+static bool AVXCapable() {
     int cpuInfo[4];
 
     // CPU support
@@ -78,7 +78,7 @@ bool AVXCapable() {
     return HW_AVX && avxSupported;
 }
 
-bool AVX512Capable() {
+static bool AVX512Capable() {
     if (!AVXCapable()) return false;
 
     int cpuInfo[4];

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -281,10 +281,10 @@ namespace hnswlib {
 #endif
 
 #if defined(USE_SSE) || defined(USE_AVX) || defined(USE_AVX512)
-    DISTFUNC<float> InnerProductSIMD16Ext = InnerProductSIMD16ExtSSE;
-    DISTFUNC<float> InnerProductSIMD4Ext = InnerProductSIMD4ExtSSE;
-    DISTFUNC<float> InnerProductDistanceSIMD16Ext = InnerProductDistanceSIMD16ExtSSE;
-    DISTFUNC<float> InnerProductDistanceSIMD4Ext = InnerProductDistanceSIMD4ExtSSE;
+    static DISTFUNC<float> InnerProductSIMD16Ext = InnerProductSIMD16ExtSSE;
+    static DISTFUNC<float> InnerProductSIMD4Ext = InnerProductSIMD4ExtSSE;
+    static DISTFUNC<float> InnerProductDistanceSIMD16Ext = InnerProductDistanceSIMD16ExtSSE;
+    static DISTFUNC<float> InnerProductDistanceSIMD4Ext = InnerProductDistanceSIMD4ExtSSE;
 
     static float
     InnerProductDistanceSIMD16ExtResiduals(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {

--- a/hnswlib/space_l2.h
+++ b/hnswlib/space_l2.h
@@ -144,7 +144,7 @@ namespace hnswlib {
 #endif
 
 #if defined(USE_SSE) || defined(USE_AVX) || defined(USE_AVX512)
-    DISTFUNC<float> L2SqrSIMD16Ext = L2SqrSIMD16ExtSSE;
+    static DISTFUNC<float> L2SqrSIMD16Ext = L2SqrSIMD16ExtSSE;
 
     static float
     L2SqrSIMD16ExtResiduals(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -96,7 +96,7 @@ public:
       l2space = new hnswlib::InnerProductSpace(dim);
       normalize=true;
     } else {
-      throw new std::runtime_error("Space name must be one of l2, ip, or cosine.");
+      throw std::runtime_error("Space name must be one of l2, ip, or cosine.");
     }
     appr_alg = NULL;
     ep_added = true;
@@ -129,7 +129,7 @@ public:
 
     void init_new_index(const size_t maxElements, const size_t M, const size_t efConstruction, const size_t random_seed) {
         if (appr_alg) {
-            throw new std::runtime_error("The index is already initiated.");
+            throw std::runtime_error("The index is already initiated.");
         }
         cur_l = 0;
         appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, maxElements, M, efConstruction, random_seed);
@@ -668,7 +668,7 @@ public:
             space = new hnswlib::InnerProductSpace(dim);
             normalize=true;
         } else {
-            throw new std::runtime_error("Space name must be one of l2, ip, or cosine.");
+            throw std::runtime_error("Space name must be one of l2, ip, or cosine.");
         }
         alg = NULL;
         index_inited = false;
@@ -693,7 +693,7 @@ public:
 
     void init_new_index(const size_t maxElements) {
         if (alg) {
-            throw new std::runtime_error("The index is already initiated.");
+            throw std::runtime_error("The index is already initiated.");
         }
         cur_l = 0;
         alg = new hnswlib::BruteforceSearch<dist_t>(space, maxElements);

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -155,7 +155,7 @@ public:
 
     void loadIndex(const std::string &path_to_index, size_t max_elements) {
       if (appr_alg) {
-          std::cerr<<"Warning: Calling load_index for an already inited index. Old index is being deallocated.";
+          std::cerr << "Warning: Calling load_index for an already inited index. Old index is being deallocated." << std::endl;
           delete appr_alg;
       }
       appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, max_elements);
@@ -768,7 +768,7 @@ public:
 
     void loadIndex(const std::string &path_to_index, size_t max_elements) {
         if (alg) {
-            std::cerr<<"Warning: Calling load_index for an already inited index. Old index is being deallocated.";
+            std::cerr << "Warning: Calling load_index for an already inited index. Old index is being deallocated." << std::endl;
             delete alg;
         }
         alg = new hnswlib::BruteforceSearch<dist_t>(space, path_to_index);

--- a/python_bindings/tests/bindings_test_recall.py
+++ b/python_bindings/tests/bindings_test_recall.py
@@ -1,88 +1,100 @@
+import os
 import hnswlib
 import numpy as np
-
-dim = 32
-num_elements = 100000
-k = 10
-nun_queries = 10
-
-# Generating sample data
-data = np.float32(np.random.random((num_elements, dim)))
-
-# Declaring index
-hnsw_index = hnswlib.Index(space='l2', dim=dim)  # possible options are l2, cosine or ip
-bf_index = hnswlib.BFIndex(space='l2', dim=dim)
-
-# Initing both hnsw and brute force indices
-# max_elements - the maximum number of elements (capacity). Will throw an exception if exceeded
-# during insertion of an element.
-# The capacity can be increased by saving/loading the index, see below.
-#
-# hnsw construction params:
-# ef_construction - controls index search speed/build speed tradeoff
-#
-# M - is tightly connected with internal dimensionality of the data. Strongly affects the memory consumption (~M)
-# Higher M leads to higher accuracy/run_time at fixed ef/efConstruction
-
-hnsw_index.init_index(max_elements=num_elements, ef_construction=200, M=16)
-bf_index.init_index(max_elements=num_elements)
-
-# Controlling the recall for hnsw by setting ef:
-# higher ef leads to better accuracy, but slower search
-hnsw_index.set_ef(200)
-
-# Set number of threads used during batch search/construction in hnsw
-# By default using all available cores
-hnsw_index.set_num_threads(1)
-
-print("Adding batch of %d elements" % (len(data)))
-hnsw_index.add_items(data)
-bf_index.add_items(data)
-
-print("Indices built")
-
-# Generating query data
-query_data = np.float32(np.random.random((nun_queries, dim)))
-
-# Query the elements and measure recall:
-labels_hnsw, distances_hnsw = hnsw_index.knn_query(query_data, k)
-labels_bf, distances_bf = bf_index.knn_query(query_data, k)
-
-# Measure recall
-correct = 0
-for i in range(nun_queries):
-    for label in labels_hnsw[i]:
-        for correct_label in labels_bf[i]:
-            if label == correct_label:
-                correct += 1
-                break
-
-print("recall is :", float(correct)/(k*nun_queries))
-
-# test serializing  the brute force index
-index_path = 'bf_index.bin'
-print("Saving index to '%s'" % index_path)
-bf_index.save_index(index_path)
-del bf_index
-
-# Re-initiating, loading the index
-bf_index = hnswlib.BFIndex(space='l2', dim=dim)
-
-print("\nLoading index from '%s'\n" % index_path)
-bf_index.load_index(index_path)
-
-# Query the brute force index again to verify that we get the same results
-labels_bf, distances_bf = bf_index.knn_query(query_data, k)
-
-# Measure recall
-correct = 0
-for i in range(nun_queries):
-    for label in labels_hnsw[i]:
-        for correct_label in labels_bf[i]:
-            if label == correct_label:
-                correct += 1
-                break
-
-print("recall after reloading is :", float(correct)/(k*nun_queries))
+import unittest
 
 
+class RandomSelfTestCase(unittest.TestCase):
+    def testRandomSelf(self):
+        dim = 32
+        num_elements = 100000
+        k = 10
+        num_queries = 20
+
+        recall_threshold = 0.95
+
+        # Generating sample data
+        data = np.float32(np.random.random((num_elements, dim)))
+
+        # Declaring index
+        hnsw_index = hnswlib.Index(space='l2', dim=dim)  # possible options are l2, cosine or ip
+        bf_index = hnswlib.BFIndex(space='l2', dim=dim)
+
+        # Initing both hnsw and brute force indices
+        # max_elements - the maximum number of elements (capacity). Will throw an exception if exceeded
+        # during insertion of an element.
+        # The capacity can be increased by saving/loading the index, see below.
+        #
+        # hnsw construction params:
+        # ef_construction - controls index search speed/build speed tradeoff
+        #
+        # M - is tightly connected with internal dimensionality of the data. Strongly affects the memory consumption (~M)
+        # Higher M leads to higher accuracy/run_time at fixed ef/efConstruction
+
+        hnsw_index.init_index(max_elements=num_elements, ef_construction=200, M=16)
+        bf_index.init_index(max_elements=num_elements)
+
+        # Controlling the recall for hnsw by setting ef:
+        # higher ef leads to better accuracy, but slower search
+        hnsw_index.set_ef(200)
+
+        # Set number of threads used during batch search/construction in hnsw
+        # By default using all available cores
+        hnsw_index.set_num_threads(1)
+
+        print("Adding batch of %d elements" % (len(data)))
+        hnsw_index.add_items(data)
+        bf_index.add_items(data)
+
+        print("Indices built")
+
+        # Generating query data
+        query_data = np.float32(np.random.random((num_queries, dim)))
+
+        # Query the elements and measure recall:
+        labels_hnsw, distances_hnsw = hnsw_index.knn_query(query_data, k)
+        labels_bf, distances_bf = bf_index.knn_query(query_data, k)
+
+        # Measure recall
+        correct = 0
+        for i in range(num_queries):
+            for label in labels_hnsw[i]:
+                for correct_label in labels_bf[i]:
+                    if label == correct_label:
+                        correct += 1
+                        break
+
+        recall_before = float(correct) / (k*num_queries)
+        print("recall is :", recall_before)
+        self.assertGreater(recall_before, recall_threshold)
+
+        # test serializing  the brute force index
+        index_path = 'bf_index.bin'
+        print("Saving index to '%s'" % index_path)
+        bf_index.save_index(index_path)
+        del bf_index
+
+        # Re-initiating, loading the index
+        bf_index = hnswlib.BFIndex(space='l2', dim=dim)
+
+        print("\nLoading index from '%s'\n" % index_path)
+        bf_index.load_index(index_path)
+
+        # Query the brute force index again to verify that we get the same results
+        labels_bf, distances_bf = bf_index.knn_query(query_data, k)
+
+        # Measure recall
+        correct = 0
+        for i in range(num_queries):
+            for label in labels_hnsw[i]:
+                for correct_label in labels_bf[i]:
+                    if label == correct_label:
+                        correct += 1
+                        break
+
+        recall_after = float(correct) / (k*num_queries)
+        print("recall after reloading is :", recall_after)
+
+        self.assertEqual(recall_before, recall_after)
+
+        os.remove(index_path)


### PR DESCRIPTION
Added -v to python unittest discovery to get nicely looking logs in actions (we can see the test names and results):

```
testRandomSelf (bindings_test.RandomSelfTestCase) ... ok
testGettingItems (bindings_test_getdata.RandomSelfTestCase) ... ok
...
```

Update tests in bindings_test_recall.py. Previously the tests almost always passed because there were no checks for recall values. I added a threshold to check that recall is high enough and doesn't change after index serialization.

