### PR TITLE
Replace deleted elements at addition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           ./searchKnnCloserFirst_test
           ./searchKnnWithFilter_test
           ./multiThreadLoad_test
+          ./multiThread_replace_test
           ./test_updates
           ./test_updates update
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6.15", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           fi
           ./searchKnnCloserFirst_test
           ./searchKnnWithFilter_test
+          ./multiThreadLoad_test
           ./test_updates
           ./test_updates update
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6.15", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         run: python -m pip install .
       
       - name: Test
+        timeout-minutes: 15
         run: python -m unittest discover -v --start-directory python_bindings/tests --pattern "*_test*.py"
   
   test_cpp:
@@ -52,6 +53,7 @@ jobs:
         shell: bash
       
       - name: Test
+        timeout-minutes: 15
         run: |
           cd build
           if [ "$RUNNER_OS" == "Windows" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ var/
 .idea/
 .vscode/
 .vs/
+**.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(CMAKE_CXX_STANDARD 11)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      SET( CMAKE_CXX_FLAGS  "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -mcpu=apple-m1 -fpic -ftree-vectorize")
+      SET( CMAKE_CXX_FLAGS  "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -ftree-vectorize")
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -march=native -fpic -w -fopenmp -ftree-vectorize -ftree-vectorizer-verbose=0" )
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(CMAKE_CXX_STANDARD 11)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      SET( CMAKE_CXX_FLAGS  "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -march=native -fpic -ftree-vectorize")
+      SET( CMAKE_CXX_FLAGS  "-Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -openmp -mcpu=apple-m1 -fpic -ftree-vectorize")
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       SET( CMAKE_CXX_FLAGS  "-Ofast -lrt -DNDEBUG -std=c++11 -DHAVE_CXX0X -march=native -fpic -w -fopenmp -ftree-vectorize -ftree-vectorizer-verbose=0" )
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -27,6 +27,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
     add_executable(multiThreadLoad_test examples/multiThreadLoad_test.cpp)
     target_link_libraries(multiThreadLoad_test hnswlib)
+
+    add_executable(multiThread_replace_test examples/multiThread_replace_test.cpp)
+    target_link_libraries(multiThread_replace_test hnswlib)
 
     add_executable(main main.cpp sift_1b.cpp)
     target_link_libraries(main hnswlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_executable(searchKnnWithFilter_test examples/searchKnnWithFilter_test.cpp)
     target_link_libraries(searchKnnWithFilter_test hnswlib)
 
+    add_executable(multiThreadLoad_test examples/multiThreadLoad_test.cpp)
+    target_link_libraries(multiThreadLoad_test hnswlib)
+
     add_executable(main main.cpp sift_1b.cpp)
     target_link_libraries(main hnswlib)
 endif()

--- a/examples/multiThreadLoad_test.cpp
+++ b/examples/multiThreadLoad_test.cpp
@@ -2,8 +2,10 @@
 #include <thread>
 
 int main() {
+
+    std::cout << "Running multithread load test" << std::endl;
     int d = 16;
-    int max_elements = 100;
+    int max_elements = 1000;
 
     std::mt19937 rng;
     rng.seed(47);
@@ -49,5 +51,6 @@ int main() {
         start_id += num_ids;
     }
     
+    std::cout << "Finish" << std::endl;
     return 0;
 }

--- a/examples/multiThreadLoad_test.cpp
+++ b/examples/multiThreadLoad_test.cpp
@@ -1,0 +1,53 @@
+#include "../hnswlib/hnswlib.h"
+#include <thread>
+
+int main() {
+    int d = 16;
+    int max_elements = 100;
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib_real;
+
+    hnswlib::L2Space space(d);
+    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements);
+
+    int num_threads = 40;
+    int num_ids = 1;
+
+    int num_iterations = 10;
+    int start_id = 0;
+
+    while (true) {
+        std::uniform_int_distribution<> distrib_int(start_id, start_id + num_ids - 1);
+        std::vector<std::thread> threads;
+        for (size_t thread_id = 0; thread_id < num_threads; thread_id++) {
+            threads.push_back(
+                std::thread(
+                    [&] {
+                        for (int iter = 0; iter < num_iterations; iter++) {
+                            std::vector<float> data(d);
+                            int id = distrib_int(rng);
+                            //std::cout << id << std::endl;
+                            for (int i = 0; i < d; i++) {
+                                data[i] = distrib_real(rng);
+                            }
+                            alg_hnsw->addPoint(data.data(), id);
+                        }
+                    }
+                )
+            );
+        }
+        for (auto &thread : threads) {
+            thread.join();
+        }
+        //std::cout << alg_hnsw->cur_element_count << std::endl;
+        if (alg_hnsw->cur_element_count > max_elements - num_ids) {
+            //std::cout << "Exit" << std::endl;
+            break;
+        }
+        start_id += num_ids;
+    }
+    
+    return 0;
+}

--- a/examples/multiThreadLoad_test.cpp
+++ b/examples/multiThreadLoad_test.cpp
@@ -14,8 +14,9 @@ int main() {
     hnswlib::L2Space space(d);
     hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements);
 
+    // with these parameters about 7 threads will do operations with the same label simultaneously
     int num_threads = 40;
-    int num_ids = 1;
+    int num_ids = 10;
 
     int num_iterations = 10;
     int start_id = 0;

--- a/examples/multiThreadLoad_test.cpp
+++ b/examples/multiThreadLoad_test.cpp
@@ -1,8 +1,9 @@
 #include "../hnswlib/hnswlib.h"
 #include <thread>
+#include <chrono>
+
 
 int main() {
-
     std::cout << "Running multithread load test" << std::endl;
     int d = 16;
     int max_elements = 1000;
@@ -12,17 +13,21 @@ int main() {
     std::uniform_real_distribution<> distrib_real;
 
     hnswlib::L2Space space(d);
-    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements);
+    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, 2 * max_elements);
 
-    // with these parameters about 7 threads will do operations with the same label simultaneously
+    std::cout << "Building index" << std::endl;
     int num_threads = 40;
-    int num_ids = 10;
+    int num_labels = 10;
 
     int num_iterations = 10;
-    int start_id = 0;
+    int start_label = 0;
 
+    // run threads that will add elements to the index
+    // about 7 threads (the number depends on num_threads and num_labels)
+    // will add/update element with the same label simultaneously
     while (true) {
-        std::uniform_int_distribution<> distrib_int(start_id, start_id + num_ids - 1);
+        // add elements by batches
+        std::uniform_int_distribution<> distrib_int(start_label, start_label + num_labels - 1);
         std::vector<std::thread> threads;
         for (size_t thread_id = 0; thread_id < num_threads; thread_id++) {
             threads.push_back(
@@ -30,12 +35,11 @@ int main() {
                     [&] {
                         for (int iter = 0; iter < num_iterations; iter++) {
                             std::vector<float> data(d);
-                            int id = distrib_int(rng);
-                            //std::cout << id << std::endl;
+                            hnswlib::labeltype label = distrib_int(rng);
                             for (int i = 0; i < d; i++) {
                                 data[i] = distrib_real(rng);
                             }
-                            alg_hnsw->addPoint(data.data(), id);
+                            alg_hnsw->addPoint(data.data(), label);
                         }
                     }
                 )
@@ -44,12 +48,91 @@ int main() {
         for (auto &thread : threads) {
             thread.join();
         }
-        //std::cout << alg_hnsw->cur_element_count << std::endl;
-        if (alg_hnsw->cur_element_count > max_elements - num_ids) {
-            //std::cout << "Exit" << std::endl;
+        if (alg_hnsw->cur_element_count > max_elements - num_labels) {
             break;
         }
-        start_id += num_ids;
+        start_label += num_labels;
+    }
+
+    // insert remaining elements if needed
+    for (hnswlib::labeltype label = 0; label < max_elements; label++) {
+        auto search = alg_hnsw->label_lookup_.find(label);
+        if (search == alg_hnsw->label_lookup_.end()) {
+            std::cout << "Adding " << label << std::endl;
+            std::vector<float> data(d);
+            for (int i = 0; i < d; i++) {
+                data[i] = distrib_real(rng);
+            }
+            alg_hnsw->addPoint(data.data(), label);
+        }
+    }
+
+    std::cout << "Index is created" << std::endl;
+
+    bool stop_threads = false;
+    std::vector<std::thread> threads;
+
+    // create threads that will do markDeleted and unmarkDeleted of random elements
+    // each thread works with specific range of labels
+    std::cout << "Starting markDeleted and unmarkDeleted threads" << std::endl;
+    num_threads = 20;
+    int chunk_size = max_elements / num_threads;
+    for (size_t thread_id = 0; thread_id < num_threads; thread_id++) {
+        threads.push_back(
+            std::thread(
+                [&, thread_id] {
+                    std::uniform_int_distribution<> distrib_int(0, chunk_size - 1);
+                    int start_id = thread_id * chunk_size;
+                    std::vector<bool> marked_deleted(chunk_size);
+                    while (!stop_threads) {
+                        int id = distrib_int(rng);
+                        hnswlib::labeltype label = start_id + id;
+                        if (marked_deleted[id]) {
+                            alg_hnsw->unmarkDelete(label);
+                            marked_deleted[id] = false;
+                        } else {
+                            alg_hnsw->markDelete(label);
+                            marked_deleted[id] = true;
+                        }
+                    }
+                }
+            )
+        );
+    }
+
+    // create threads that will add and update random elements
+    std::cout << "Starting add and update elements threads" << std::endl;
+    num_threads = 20;
+    std::uniform_int_distribution<> distrib_int_add(max_elements, 2 * max_elements - 1);
+    for (size_t thread_id = 0; thread_id < num_threads; thread_id++) {
+        threads.push_back(
+            std::thread(
+                [&] {
+                    std::vector<float> data(d);
+                    while (!stop_threads) {
+                        hnswlib::labeltype label = distrib_int_add(rng);
+                        for (int i = 0; i < d; i++) {
+                            data[i] = distrib_real(rng);
+                        }
+                        alg_hnsw->addPoint(data.data(), label);
+                        std::vector<float> data = alg_hnsw->getDataByLabel<float>(label);
+                        float max_val = *max_element(data.begin(), data.end());
+                        // never happens but prevents compiler from deleting unused code
+                        if (max_val > 10) {
+                            throw std::runtime_error("Unexpected value in data");
+                        }
+                    }
+                }
+            )
+        );
+    }
+
+    std::cout << "Sleep and continue operations with index" << std::endl;
+    int sleep_ms = 60 * 1000;
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+    stop_threads = true;
+    for (auto &thread : threads) {
+        thread.join();
     }
     
     std::cout << "Finish" << std::endl;

--- a/examples/multiThread_replace_test.cpp
+++ b/examples/multiThread_replace_test.cpp
@@ -104,7 +104,7 @@ int main() {
 
         std::cout << "Updating elements\n";
         ParallelFor(0, num_elements, num_threads, [&](size_t row, size_t threadId) {
-            int label = rand_labels[row] + 10000;
+            int label = rand_labels[row] + max_elements;
             alg_hnsw->addPoint((void*)(batch2 + d * row), label, true);
         });
 

--- a/examples/multiThread_replace_test.cpp
+++ b/examples/multiThread_replace_test.cpp
@@ -100,13 +100,13 @@ int main() {
             alg_hnsw->addPoint((void*)(batch1 + d * row), row);
         });
 
-        // delete batch1 data
+        // delete half random elements of batch1 data
         std::cout << "Deleting\n";
         for (int i = 0; i < num_elements; i++) {
             alg_hnsw->markDelete(rand_labels[i]);
         }
 
-        // replace batch1 data with batch2 data
+        // replace deleted elements with batch2 data
         std::cout << "Updating elements\n";
         ParallelFor(0, num_elements, num_threads, [&](size_t row, size_t threadId) {
             int label = rand_labels[row] + max_elements;

--- a/examples/multiThread_replace_test.cpp
+++ b/examples/multiThread_replace_test.cpp
@@ -71,11 +71,11 @@ int main() {
 
     hnswlib::L2Space space(d);
 
-    float batch1[d * max_elements];
+    float* batch1 = new float[d * max_elements];
     for (int i = 0; i < d * max_elements; i++) {
         batch1[i] = distrib_real(rng);
     }
-    float batch2[d * num_elements];
+    float* batch2 = new float[d * num_elements];
     for (int i = 0; i < d * num_elements; i++) {
         batch2[i] = distrib_real(rng);
     }
@@ -114,5 +114,8 @@ int main() {
     }
     
     std::cout << "Finish" << std::endl;
+
+    delete[] batch1;
+    delete[] batch2;
     return 0;
 }

--- a/examples/multiThread_replace_test.cpp
+++ b/examples/multiThread_replace_test.cpp
@@ -90,24 +90,19 @@ int main() {
 
     int iter = 0;
     while (iter < 200) {
-        std::cout << iter << std::endl;
-
         hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, 16, 200, 123, true);
 
         // add batch1 data
-        std::cout << "Building index\n";
         ParallelFor(0, max_elements, num_threads, [&](size_t row, size_t threadId) {
             alg_hnsw->addPoint((void*)(batch1 + d * row), row);
         });
 
         // delete half random elements of batch1 data
-        std::cout << "Deleting\n";
         for (int i = 0; i < num_elements; i++) {
             alg_hnsw->markDelete(rand_labels[i]);
         }
 
         // replace deleted elements with batch2 data
-        std::cout << "Updating elements\n";
         ParallelFor(0, num_elements, num_threads, [&](size_t row, size_t threadId) {
             int label = rand_labels[row] + max_elements;
             alg_hnsw->addPoint((void*)(batch2 + d * row), label, true);

--- a/examples/multiThread_replace_test.cpp
+++ b/examples/multiThread_replace_test.cpp
@@ -89,7 +89,7 @@ int main() {
     std::shuffle(rand_labels.begin(), rand_labels.end(), rng);
 
     int iter = 0;
-    while (iter < 1000) {
+    while (iter < 200) {
         std::cout << iter << std::endl;
 
         hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, 16, 200, 123, true);

--- a/examples/multiThread_replace_test.cpp
+++ b/examples/multiThread_replace_test.cpp
@@ -1,0 +1,118 @@
+#include "../hnswlib/hnswlib.h"
+#include <thread>
+#include <chrono>
+
+
+template<class Function>
+inline void ParallelFor(size_t start, size_t end, size_t numThreads, Function fn) {
+    if (numThreads <= 0) {
+        numThreads = std::thread::hardware_concurrency();
+    }
+
+    if (numThreads == 1) {
+        for (size_t id = start; id < end; id++) {
+            fn(id, 0);
+        }
+    } else {
+        std::vector<std::thread> threads;
+        std::atomic<size_t> current(start);
+
+        // keep track of exceptions in threads
+        // https://stackoverflow.com/a/32428427/1713196
+        std::exception_ptr lastException = nullptr;
+        std::mutex lastExceptMutex;
+
+        for (size_t threadId = 0; threadId < numThreads; ++threadId) {
+            threads.push_back(std::thread([&, threadId] {
+                while (true) {
+                    size_t id = current.fetch_add(1);
+
+                    if (id >= end) {
+                        break;
+                    }
+
+                    try {
+                        fn(id, threadId);
+                    } catch (...) {
+                        std::unique_lock<std::mutex> lastExcepLock(lastExceptMutex);
+                        lastException = std::current_exception();
+                        /*
+                         * This will work even when current is the largest value that
+                         * size_t can fit, because fetch_add returns the previous value
+                         * before the increment (what will result in overflow
+                         * and produce 0 instead of current + 1).
+                         */
+                        current = end;
+                        break;
+                    }
+                }
+            }));
+        }
+        for (auto &thread : threads) {
+            thread.join();
+        }
+        if (lastException) {
+            std::rethrow_exception(lastException);
+        }
+    }
+}
+
+
+int main() {
+    std::cout << "Running multithread load test" << std::endl;
+    int d = 16;
+    int num_elements = 1000;
+    int max_elements = 2 * num_elements;
+    int num_threads = 50;
+
+    std::mt19937 rng;
+    rng.seed(47);
+    std::uniform_real_distribution<> distrib_real;
+
+    hnswlib::L2Space space(d);
+
+    float batch1[d * max_elements];
+    for (int i = 0; i < d * max_elements; i++) {
+        batch1[i] = distrib_real(rng);
+    }
+    float batch2[d * num_elements];
+    for (int i = 0; i < d * num_elements; i++) {
+        batch2[i] = distrib_real(rng);
+    }
+
+    std::vector<int> rand_labels(max_elements);
+    for (int i = 0; i < max_elements; i++) {
+        rand_labels[i] = i;
+    }
+    std::shuffle(rand_labels.begin(), rand_labels.end(), rng);
+
+    int iter = 0;
+    while (iter < 1000) {
+        std::cout << iter << std::endl;
+
+        hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, 16, 200, 123, true);
+
+        std::cout << "Building index\n";
+        ParallelFor(0, max_elements, num_threads, [&](size_t row, size_t threadId) {
+            alg_hnsw->addPoint((void*)(batch1 + d * row), row);
+        });
+
+        std::cout << "Deleting\n";
+        for (int i = 0; i < num_elements; i++) {
+            alg_hnsw->markDelete(rand_labels[i]);
+        }
+
+        std::cout << "Updating elements\n";
+        ParallelFor(0, num_elements, num_threads, [&](size_t row, size_t threadId) {
+            int label = rand_labels[row] + 10000;
+            alg_hnsw->addPoint((void*)(batch2 + d * row), label, true);
+        });
+
+        iter += 1;
+
+        delete alg_hnsw;
+    }
+    
+    std::cout << "Finish" << std::endl;
+    return 0;
+}

--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -61,7 +61,7 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
     }
 
 
-    void addPoint(const void *datapoint, labeltype label) {
+    void addPoint(const void *datapoint, labeltype label, bool replace_deleted = false) {
         int idx;
         {
             std::unique_lock<std::mutex> lock(index_lock);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -451,6 +451,8 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         tableint next_closest_entry_point = selectedNeighbors.back();
 
         {
+            // lock only during the update
+            // because during the addition the lock for cur_c is already acquired
             std::unique_lock <std::mutex> lock(link_list_locks_[cur_c], std::defer_lock);
             if (isUpdate) {
                 lock.lock();

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -855,6 +855,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         std::unique_lock <std::mutex> lock_label(getLabelOpMutex(label));
         if (!replace_deleted) {
             addPoint(data_point, label, -1);
+            return;
         }
         // check if there is vacant place
         tableint internal_id_replaced;

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -785,7 +785,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     * Removes the deleted mark of the node, does NOT really change the current graph.
     * 
     * Note: the method is not safe to use when replacement of deleted elements is enabled,
-    *  bacause elements marked as deleted can be completely removed by addPointToVacantPlace
+    *  because elements marked as deleted can be completely removed by addPointToVacantPlace
     */
     void unmarkDelete(labeltype label) {
         // lock all operations with element by label
@@ -895,7 +895,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     * Adds point. Updates the point if it is already in the index
     *
     * Note: the method is not safe to use to update elements when replacement of deleted elements is enabled,
-    *  bacause elements marked as deleted can be completely removed by addPointToVacantPlace: 
+    *  because elements marked as deleted can be completely removed by addPointToVacantPlace: 
     */
     void addPoint(const void *data_point, labeltype label) {
         // lock all operations with element by label

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -451,6 +451,10 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         tableint next_closest_entry_point = selectedNeighbors.back();
 
         {
+            std::unique_lock <std::mutex> lock(link_list_locks_[cur_c], std::defer_lock);
+            if (isUpdate) {
+                lock.lock();
+            }
             linklistsizeint *ll_cur;
             if (level == 0)
                 ll_cur = get_linklist0(cur_c);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -20,7 +20,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     static const unsigned char DELETE_MARK = 0x01;
 
     size_t max_elements_{0};
-    size_t cur_element_count{0};
+    mutable std::atomic<size_t> cur_element_count{0};  // current number of elements
     size_t size_data_per_element_{0};
     size_t size_links_per_element_{0};
     mutable std::atomic<size_t> num_deleted_{0};  // number of deleted elements

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -158,7 +158,7 @@ class SpaceInterface {
 template<typename dist_t>
 class AlgorithmInterface {
  public:
-    virtual void addPoint(const void *datapoint, labeltype label) = 0;
+    virtual void addPoint(const void *datapoint, labeltype label, bool replace_deleted = false) = 0;
 
     virtual std::priority_queue<std::pair<dist_t, labeltype>>
         searchKnn(const void*, size_t, BaseFilterFunctor* isIdAllowed = nullptr) const = 0;

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -473,7 +473,7 @@ class Index {
         return py::dict(
             "offset_level0"_a = appr_alg->offsetLevel0_,
             "max_elements"_a = appr_alg->max_elements_,
-            "cur_element_count"_a = appr_alg->cur_element_count,
+            "cur_element_count"_a = (size_t)appr_alg->cur_element_count,
             "size_data_per_element"_a = appr_alg->size_data_per_element_,
             "label_offset"_a = appr_alg->label_offset_,
             "offset_data"_a = appr_alg->offsetData_,
@@ -1006,7 +1006,7 @@ PYBIND11_PLUGIN(hnswlib) {
             return index.index_inited ? index.appr_alg->max_elements_ : 0;
         })
         .def_property_readonly("element_count", [](const Index<float> & index) {
-            return index.index_inited ? index.appr_alg->cur_element_count : 0;
+            return index.index_inited ? (size_t)index.appr_alg->cur_element_count : 0;
         })
         .def_property_readonly("ef_construction", [](const Index<float> & index) {
           return index.index_inited ? index.appr_alg->ef_construction_ : 0;

--- a/python_bindings/tests/bindings_test_filter.py
+++ b/python_bindings/tests/bindings_test_filter.py
@@ -49,7 +49,7 @@ class RandomSelfTestCase(unittest.TestCase):
         filter_function = lambda id: id%2 == 0
         labels, distances = hnsw_index.knn_query(data, k=1, filter=filter_function)
         self.assertAlmostEqual(np.mean(labels.reshape(-1) == np.arange(len(data))), .5, 3)
-        # Verify that there are onle even elements:
+        # Verify that there are only even elements:
         self.assertTrue(np.max(np.mod(labels, 2)) == 0)
 
         labels, distances = bf_index.knn_query(data, k=1, filter=filter_function)

--- a/python_bindings/tests/bindings_test_recall.py
+++ b/python_bindings/tests/bindings_test_recall.py
@@ -40,7 +40,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Set number of threads used during batch search/construction in hnsw
         # By default using all available cores
-        hnsw_index.set_num_threads(1)
+        hnsw_index.set_num_threads(4)
 
         print("Adding batch of %d elements" % (len(data)))
         hnsw_index.add_items(data)

--- a/python_bindings/tests/bindings_test_replace.py
+++ b/python_bindings/tests/bindings_test_replace.py
@@ -57,7 +57,7 @@ class RandomSelfTestCase(unittest.TestCase):
         for l in labels2_deleted:
             hnsw_index.mark_deleted(l[0])
         labels1_found, _ = hnsw_index.knn_query(data1, k=1)
-        items = hnsw_index.get_items(labels1)
+        items = hnsw_index.get_items(labels1_found)
         diff_with_gt_labels = np.mean(np.abs(data1-items))
         self.assertAlmostEqual(diff_with_gt_labels, 0, delta=1e-3)
 

--- a/python_bindings/tests/bindings_test_replace.py
+++ b/python_bindings/tests/bindings_test_replace.py
@@ -40,7 +40,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Declaring index
         hnsw_index = hnswlib.Index(space='l2', dim=dim)
-        hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, replace_deleted=True)
+        hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, allow_replace_deleted=True)
 
         hnsw_index.set_ef(100)
         hnsw_index.set_num_threads(4)
@@ -106,7 +106,7 @@ class RandomSelfTestCase(unittest.TestCase):
         hnsw_index = hnswlib.Index(space='l2', dim=dim)  # the space can be changed - keeps the data, alters the distance function.
         hnsw_index.set_num_threads(4)
         print(f"Loading index from {index_path}")
-        hnsw_index.load_index(index_path, max_elements=max_num_elements, replace_deleted=True)
+        hnsw_index.load_index(index_path, max_elements=max_num_elements, allow_replace_deleted=True)
 
         # Insert batch 4
         print("Inserting batch 4 by replacing deleted elements")

--- a/python_bindings/tests/bindings_test_replace.py
+++ b/python_bindings/tests/bindings_test_replace.py
@@ -13,6 +13,8 @@ class RandomSelfTestCase(unittest.TestCase):
         num_elements = 5000
         max_num_elements = 2 * num_elements
 
+        recall_threshold = 0.98
+
         # Generating sample data
         print("Generating data")
         # batch 1
@@ -119,7 +121,7 @@ class RandomSelfTestCase(unittest.TestCase):
         labels_found, _ = hnsw_index.knn_query(data4, k=1)
         recall = np.mean(labels_found.reshape(-1) == labels4)
         print(f"Recall for the 4 batch: {recall}")
-        self.assertGreater(recall, 0.98)
+        self.assertGreater(recall, recall_threshold)
 
         # Delete batch 4
         print("Deleting batch 4")
@@ -138,6 +140,6 @@ class RandomSelfTestCase(unittest.TestCase):
         labels_found, _ = hnsw_index_pckl.knn_query(data3, k=1)
         recall = np.mean(labels_found.reshape(-1) == labels3)
         print(f"Recall for the 3 batch: {recall}")
-        self.assertGreater(recall, 0.98)
+        self.assertGreater(recall, recall_threshold)
 
         os.remove(index_path)

--- a/python_bindings/tests/bindings_test_replace.py
+++ b/python_bindings/tests/bindings_test_replace.py
@@ -72,7 +72,7 @@ class RandomSelfTestCase(unittest.TestCase):
         print("Inserting batch 3 by replacing deleted elements")
         # Maximum number of elements is reached therefore we cannot add new items
         # but we can replace the deleted ones
-        labels_replaced = hnsw_index.insert_items(data3, labels3)
+        labels_replaced = hnsw_index.add_items_to_vacant_place(data3, labels3)
         labels2_deleted_list = [l[0] for l in labels2_deleted]
         labels_replaced_list = labels_replaced.tolist()
         labels2_deleted_list.sort()
@@ -114,7 +114,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Insert batch 4
         print("Inserting batch 4 by replacing deleted elements")
-        labels_replaced = hnsw_index.insert_items(data4, labels4)
+        labels_replaced = hnsw_index.add_items_to_vacant_place(data4, labels4)
 
         # Check recall
         print("Checking recall")
@@ -133,7 +133,7 @@ class RandomSelfTestCase(unittest.TestCase):
         del hnsw_index
         # Insert batch 3
         print("Inserting batch 3 by replacing deleted elements")
-        labels_replaced = hnsw_index_pckl.insert_items(data3, labels3)
+        labels_replaced = hnsw_index_pckl.add_items_to_vacant_place(data3, labels3)
 
         # Check recall
         print("Checking recall")

--- a/python_bindings/tests/bindings_test_replace.py
+++ b/python_bindings/tests/bindings_test_replace.py
@@ -1,0 +1,143 @@
+import os
+import pickle
+import unittest
+
+import numpy as np
+
+import hnswlib
+
+
+class RandomSelfTestCase(unittest.TestCase):
+    def testRandomSelf(self):
+        dim = 16
+        num_elements = 5000
+        max_num_elements = 2 * num_elements
+
+        # Generating sample data
+        print("Generating data")
+        # batch 1
+        first_id = 0
+        last_id = num_elements
+        labels1 = np.arange(first_id, last_id)
+        data1 = np.float32(np.random.random((num_elements, dim)))
+        # batch 2
+        first_id += num_elements
+        last_id += num_elements
+        labels2 = np.arange(first_id, last_id)
+        data2 = np.float32(np.random.random((num_elements, dim)))
+        # batch 3
+        first_id += num_elements
+        last_id += num_elements
+        labels3 = np.arange(first_id, last_id)
+        data3 = np.float32(np.random.random((num_elements, dim)))
+        # batch 4
+        first_id += num_elements
+        last_id += num_elements
+        labels4 = np.arange(first_id, last_id)
+        data4 = np.float32(np.random.random((num_elements, dim)))
+
+        # Declaring index
+        hnsw_index = hnswlib.Index(space='l2', dim=dim)
+        hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, replace_deleted=True)
+
+        hnsw_index.set_ef(100)
+        hnsw_index.set_num_threads(4)
+
+        # Add batch 1 and 2
+        print("Adding batch 1")
+        hnsw_index.add_items(data1, labels1)
+        print("Adding batch 2")
+        hnsw_index.add_items(data2, labels2)  # maximum number of elements is reached
+
+        # Delete nearest neighbors of batch 2
+        print("Deleting neighbors of batch 2")
+        labels2_deleted, _ = hnsw_index.knn_query(data2, k=1)
+        for l in labels2_deleted:
+            hnsw_index.mark_deleted(l[0])
+        labels1_found, _ = hnsw_index.knn_query(data1, k=1)
+        items = hnsw_index.get_items(labels1)
+        diff_with_gt_labels = np.mean(np.abs(data1-items))
+        self.assertAlmostEqual(diff_with_gt_labels, 0, delta=1e-3)
+
+        labels2_after, _ = hnsw_index.knn_query(data2, k=1)
+        for la in labels2_after:
+            for lb in labels2_deleted:
+                if la[0] == lb[0]:
+                    self.assertTrue(False)
+        print("All the neighbors of data2 are removed")
+
+        # Replace deleted elements
+        print("Inserting batch 3 by replacing deleted elements")
+        # Maximum number of elements is reached therefore we cannot add new items
+        # but we can replace the deleted ones
+        labels_replaced = hnsw_index.insert_items(data3, labels3)
+        labels2_deleted_list = [l[0] for l in labels2_deleted]
+        labels_replaced_list = labels_replaced.tolist()
+        labels2_deleted_list.sort()
+        labels_replaced_list.sort()
+        self.assertSequenceEqual(labels2_deleted_list, labels_replaced_list)
+
+        # After replacing, all labels should be retrievable
+        print("Checking that remaining labels are in index")
+        # Get remaining data from batch 1 and batch 2 after deletion of elements
+        remaining_labels = set(labels1) | set(labels2)
+        remaining_labels = remaining_labels - set(labels2_deleted_list)
+        remaining_labels_list = list(remaining_labels)
+        comb_data = np.concatenate((data1, data2), axis=0)
+        remaining_data = comb_data[remaining_labels_list]
+
+        returned_items = hnsw_index.get_items(remaining_labels_list)
+        self.assertSequenceEqual(remaining_data.tolist(), returned_items)
+
+        returned_items = hnsw_index.get_items(labels3)
+        self.assertSequenceEqual(data3.tolist(), returned_items)
+
+        # Check index serialization
+        # Delete batch 3
+        print("Deleting batch 3")
+        for l in labels3:
+            hnsw_index.mark_deleted(l)
+
+        # Save index
+        index_path = "index.bin"
+        print(f"Saving index to {index_path}")
+        hnsw_index.save_index(index_path)
+        del hnsw_index
+
+        # Reinit and load the index
+        hnsw_index = hnswlib.Index(space='l2', dim=dim)  # the space can be changed - keeps the data, alters the distance function.
+        hnsw_index.set_num_threads(4)
+        print(f"Loading index from {index_path}")
+        hnsw_index.load_index(index_path, max_elements=max_num_elements, replace_deleted=True)
+
+        # Insert batch 4
+        print("Inserting batch 4 by replacing deleted elements")
+        labels_replaced = hnsw_index.insert_items(data4, labels4)
+
+        # Check recall
+        print("Checking recall")
+        labels_found, _ = hnsw_index.knn_query(data4, k=1)
+        recall = np.mean(labels_found.reshape(-1) == labels4)
+        print(f"Recall for the 4 batch: {recall}")
+        self.assertGreater(recall, 0.98)
+
+        # Delete batch 4
+        print("Deleting batch 4")
+        for l in labels4:
+            hnsw_index.mark_deleted(l)
+
+        print("Testing pickle serialization")
+        hnsw_index_pckl = pickle.loads(pickle.dumps(hnsw_index))
+        del hnsw_index
+        # Insert batch 3
+        print("Inserting batch 3 by replacing deleted elements")
+        labels_replaced = hnsw_index_pckl.insert_items(data3, labels3)
+
+        # Check recall
+        print("Checking recall")
+        labels_found, _ = hnsw_index_pckl.knn_query(data3, k=1)
+        recall = np.mean(labels_found.reshape(-1) == labels3)
+        print(f"Recall for the 3 batch: {recall}")
+        self.assertGreater(recall, 0.98)
+
+        os.remove(index_path)

--- a/python_bindings/tests/bindings_test_replace.py
+++ b/python_bindings/tests/bindings_test_replace.py
@@ -72,17 +72,13 @@ class RandomSelfTestCase(unittest.TestCase):
         print("Inserting batch 3 by replacing deleted elements")
         # Maximum number of elements is reached therefore we cannot add new items
         # but we can replace the deleted ones
-        labels_replaced = hnsw_index.add_items_to_vacant_place(data3, labels3)
-        labels2_deleted_list = [l[0] for l in labels2_deleted]
-        labels_replaced_list = labels_replaced.tolist()
-        labels2_deleted_list.sort()
-        labels_replaced_list.sort()
-        self.assertSequenceEqual(labels2_deleted_list, labels_replaced_list)
+        hnsw_index.add_items(data3, labels3, replace_deleted=True)
 
         # After replacing, all labels should be retrievable
         print("Checking that remaining labels are in index")
         # Get remaining data from batch 1 and batch 2 after deletion of elements
         remaining_labels = set(labels1) | set(labels2)
+        labels2_deleted_list = [l[0] for l in labels2_deleted]
         remaining_labels = remaining_labels - set(labels2_deleted_list)
         remaining_labels_list = list(remaining_labels)
         comb_data = np.concatenate((data1, data2), axis=0)
@@ -114,7 +110,7 @@ class RandomSelfTestCase(unittest.TestCase):
 
         # Insert batch 4
         print("Inserting batch 4 by replacing deleted elements")
-        labels_replaced = hnsw_index.add_items_to_vacant_place(data4, labels4)
+        hnsw_index.add_items(data4, labels4, replace_deleted=True)
 
         # Check recall
         print("Checking recall")
@@ -133,7 +129,7 @@ class RandomSelfTestCase(unittest.TestCase):
         del hnsw_index
         # Insert batch 3
         print("Inserting batch 3 by replacing deleted elements")
-        labels_replaced = hnsw_index_pckl.add_items_to_vacant_place(data3, labels3)
+        hnsw_index_pckl.add_items(data3, labels3, replace_deleted=True)
 
         # Check recall
         print("Checking recall")

--- a/python_bindings/tests/bindings_test_stress_mt_replace.py
+++ b/python_bindings/tests/bindings_test_stress_mt_replace.py
@@ -31,7 +31,7 @@ class RandomSelfTestCase(unittest.TestCase):
         # Declaring index
         for _ in range(100):
             hnsw_index = hnswlib.Index(space='l2', dim=dim)
-            hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, replace_deleted=True)
+            hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, allow_replace_deleted=True)
 
             hnsw_index.set_ef(100)
             hnsw_index.set_num_threads(50)

--- a/python_bindings/tests/bindings_test_stress_mt_replace.py
+++ b/python_bindings/tests/bindings_test_stress_mt_replace.py
@@ -58,5 +58,5 @@ class RandomSelfTestCase(unittest.TestCase):
             # Replace deleted elements
             # Maximum number of elements is reached therefore we cannot add new items
             # but we can replace the deleted ones
-            labels_replaced = hnsw_index.add_items_to_vacant_place(data3, labels3)
+            labels_replaced = hnsw_index.add_items(data3, labels3, replace_deleted=True)
        

--- a/python_bindings/tests/bindings_test_stress_mt_replace.py
+++ b/python_bindings/tests/bindings_test_stress_mt_replace.py
@@ -28,8 +28,8 @@ class RandomSelfTestCase(unittest.TestCase):
         labels3 = np.arange(first_id, last_id)
         data3 = np.float32(np.random.random((num_elements, dim)))
 
-        # Declaring index
         for _ in range(100):
+            # Declaring index
             hnsw_index = hnswlib.Index(space='l2', dim=dim)
             hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, allow_replace_deleted=True)
 

--- a/python_bindings/tests/bindings_test_stress_mt_replace.py
+++ b/python_bindings/tests/bindings_test_stress_mt_replace.py
@@ -1,0 +1,62 @@
+import unittest
+
+import numpy as np
+
+import hnswlib
+
+
+class RandomSelfTestCase(unittest.TestCase):
+    def testRandomSelf(self):
+        dim = 16
+        num_elements = 1_000
+        max_num_elements = 2 * num_elements
+
+        # Generating sample data
+        # batch 1
+        first_id = 0
+        last_id = num_elements
+        labels1 = np.arange(first_id, last_id)
+        data1 = np.float32(np.random.random((num_elements, dim)))
+        # batch 2
+        first_id += num_elements
+        last_id += num_elements
+        labels2 = np.arange(first_id, last_id)
+        data2 = np.float32(np.random.random((num_elements, dim)))
+        # batch 3
+        first_id += num_elements
+        last_id += num_elements
+        labels3 = np.arange(first_id, last_id)
+        data3 = np.float32(np.random.random((num_elements, dim)))
+
+        # Declaring index
+        for _ in range(100):
+            hnsw_index = hnswlib.Index(space='l2', dim=dim)
+            hnsw_index.init_index(max_elements=max_num_elements, ef_construction=200, M=16, replace_deleted=True)
+
+            hnsw_index.set_ef(100)
+            hnsw_index.set_num_threads(50)
+
+            # Add batch 1 and 2
+            hnsw_index.add_items(data1, labels1)
+            hnsw_index.add_items(data2, labels2)  # maximum number of elements is reached
+
+            # Delete nearest neighbors of batch 2
+            labels2_deleted, _ = hnsw_index.knn_query(data2, k=1)
+            for l in labels2_deleted:
+                hnsw_index.mark_deleted(l[0])
+            labels1_found, _ = hnsw_index.knn_query(data1, k=1)
+            items = hnsw_index.get_items(labels1_found)
+            diff_with_gt_labels = np.mean(np.abs(data1-items))
+            self.assertAlmostEqual(diff_with_gt_labels, 0, delta=1e-3)
+
+            labels2_after, _ = hnsw_index.knn_query(data2, k=1)
+            labels2_after_flat = labels2_after.flatten()
+            labels2_deleted_flat = labels2_deleted.flatten()
+            common = np.intersect1d(labels2_after_flat, labels2_deleted_flat)
+            self.assertTrue(common.size == 0)
+
+            # Replace deleted elements
+            # Maximum number of elements is reached therefore we cannot add new items
+            # but we can replace the deleted ones
+            labels_replaced = hnsw_index.add_items_to_vacant_place(data3, labels3)
+       


### PR DESCRIPTION
Added a new method to replace a deleted element when a new one is added:
`labeltype addPointToVacantPlace(const void* data_point, labeltype label)`

The method is the same as `addPoint` but allows to replace a deleted element with a new one to save memory. Note: addPointToVacantPlace is much slower than addPoint, because replacement is a heavy operation.

Edit:
- Added replace a deleted element when a new one is added
- Fix of https://github.com/nmslib/hnswlib/issues/420 by introducing locks by label
- Added a multi thread test to test against concurrent operations with the same labels
- Added timeout to test jobs in actions in case if we have deadlock
- Refactoring
