### PR TITLE
Getters for max elements and current element count

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -182,6 +182,14 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t, filter_func_t> {
         return (int) r;
     }
 
+    size_t getMaxElements() {
+        return max_elements_;
+    }
+
+    size_t getCurrentElementCount() {
+        std::unique_lock<std::mutex> templock_curr(cur_element_count_guard_);
+        return cur_element_count;
+    }
 
     std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
     searchBaseLayer(tableint ep_id, const void *data_point, int layer) {


### PR DESCRIPTION
These getters are useful for resizing of the index from outside when the element count reaches capacity.