### PR TITLE
Add CMake install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.26)
 
 project(hnswlib
     LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,36 @@
-cmake_minimum_required (VERSION 2.6)
-project(hnsw_lib
+cmake_minimum_required(VERSION 3.0)
+
+project(hnswlib
     LANGUAGES CXX)
 
-add_library(hnswlib INTERFACE)
-target_include_directories(hnswlib INTERFACE .) 
+include(GNUInstallDirs)
 
+add_library(hnswlib INTERFACE)
+add_library(hnswlib::hnswlib ALIAS hnswlib)
+
+target_include_directories(hnswlib INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# Install
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hnswlib
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS hnswlib
+    EXPORT hnswlibTargets)
+
+install(EXPORT hnswlibTargets
+    FILE hnswlibConfig.cmake
+    NAMESPACE hnswlib::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hnswlib)
+
+# Examples and tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(HNSWLIB_EXAMPLES "Build examples and tests." ON)
+else()
+    option(HNSWLIB_EXAMPLES "Build examples and tests." OFF)
+endif()
+if(HNSWLIB_EXAMPLES)
     set(CMAKE_CXX_STANDARD 11)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
Add CMake install targets to allow installing the library using CMake and allow usage with find_package().

Other changes:
- Raise the minimum CMake version to 3.0. Testing CMake 2.8.12.2 on CentOS 7 generated errors already before doing these changes.
- Make the CMake project() name consistent with the library name (change `hnsw_lib` to `hnswlib`).
- Add option `HNSWLIB_EXAMPLES` to allow enabling/disabling tests and examples explicitly. Option defaults to previous behavior checking `CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME`