### PR TITLE
Resolve wheel build failure on x86_64 architecture due to -march=native flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == 'darwin':
-        if platform.machine() == 'arm64':
+        if platform.machine() in ['arm64', 'x86_64']:
             c_opts['unix'].remove('-march=native')
         c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
         link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']


### PR DESCRIPTION
The hnswlib wheel build failed on my MacOS (x86_64 architecture) when I run ```pip install hnswlib```. 
```
      clang: error: the clang compiler does not support '-march=native'
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for hnswlib
Failed to build hnswlib
ERROR: Could not build wheels for hnswlib, which is required to install pyproject.toml-based projects
```
Similar to the solution of the previous merged [PR](https://github.com/nmslib/hnswlib/pull/363), by removing the building flag resolves the issue.
```
pip install .
Looking in indexes: https://pypi.python.org/simple/
...
Successfully built hnswlib
Installing collected packages: hnswlib
Successfully installed hnswlib-0.7.0

```