### PR TITLE
Fix heap buffer overflow caused by prefetch.

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -249,8 +249,8 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
                 tableint candidate_id = *(datal + j);
 //                    if (candidate_id == 0) continue;
 #ifdef USE_SSE
-                _mm_prefetch((char *) (visited_array + *(datal + j + 1)), _MM_HINT_T0);
-                _mm_prefetch(getDataByInternalId(*(datal + j + 1)), _MM_HINT_T0);
+                _mm_prefetch((char *) (visited_array + *(datal + j)), _MM_HINT_T0);
+                _mm_prefetch(getDataByInternalId(*(datal + j)), _MM_HINT_T0);
 #endif
                 if (visited_array[candidate_id] == visited_array_tag) continue;
                 visited_array[candidate_id] = visited_array_tag;


### PR DESCRIPTION
The prefetching goes past `size` since `datal` is initialized 1 index past `data`. 

I uncovered this issue on ASAN when SSE is enabled. Also spotted earlier here: https://github.com/nmslib/hnswlib/issues/107

cc @dyashuni 