### PR TITLE
Add virtual destructor to BaseFilterFunctor

### DIFF
--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -119,6 +119,7 @@ typedef size_t labeltype;
 class BaseFilterFunctor {
  public:
     virtual bool operator()(hnswlib::labeltype id) { return true; }
+    virtual ~BaseFilterFunctor() {};
 };
 
 template <typename T>


### PR DESCRIPTION
This pull request solves the problem caused by BaseFilterFunctor not having a virtual destructor.

Example code:

```cpp
#include <iostream>
#include "hnswlib/hnswlib.h"

class CustomFilterFunctor : public hnswlib::BaseFilterFunctor {
  public:
    CustomFilterFunctor() {
      std::cout << "constructor called" << std::endl;
    }

    bool operator()(hnswlib::labeltype id) {
      return id % 2 == 0;
    }

    ~CustomFilterFunctor() {
      std::cout << "destructor called" << std::endl;
    }
};

int main(int argc, char* argv[]) {
  hnswlib::BaseFilterFunctor* filter = new CustomFilterFunctor();
  delete filter;
  return 0;
}
```

Compiling with `-Wall` option, a warning message about the lack of a virtual destructor is output:

```sh
$ g++ -Wall -std=c++11 example.cpp
example.cpp:19:3: warning: delete called on non-final 'hnswlib::BaseFilterFunctor' that has virtual functions but non-virtual destructor [-Wdelete
-non-abstract-non-virtual-dtor]
  delete filter;
$ ./a.out
constructor called
```
 
CustomFilterFunctor's destructor was not called because the implicitly created BaseFilterFunctor's destructor was called. For example, when CustomFuncFilter is an implementation that releases the allocated memory in it's destructor, the problem occurs that the destructor is not called and the memory is not released. This issue is resolved by adding a virtual destructor to BaseFilterFunctor.
