### PR TITLE
Fixed linking error with Visual Studio

### DIFF
--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -15,7 +15,7 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #include <stdexcept>
-void cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
+static void cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
     __cpuidex(out, eax, ecx);
 }
 static __int64 xgetbv(unsigned int x) {


### PR DESCRIPTION
If you include the header hnswlib/hnswlib.h in multiple C++ files and compile with Visual Studio then you get the following error

  error LNK2005: "void __cdecl cpuid(int * const,int,int)" (?cpuid@@YAXQEAHHH@Z) already defined in Pch.obj
  fatal error LNK1169: one or more multiply defined symbols found

This is easy to fix by declaring the function cpuid() static