### PR TITLE
Fix build warnings.

### DIFF
--- a/tests/cpp/sift_1b.cpp
+++ b/tests/cpp/sift_1b.cpp
@@ -250,11 +250,11 @@ void sift_test1B() {
     size_t vecdim = 128;
     char path_index[1024];
     char path_gt[1024];
-    char *path_q = "../bigann/bigann_query.bvecs";
-    char *path_data = "../bigann/bigann_base.bvecs";
-    sprintf(path_index, "sift1b_%dm_ef_%d_M_%d.bin", subset_size_milllions, efConstruction, M);
+    const char *path_q = "../bigann/bigann_query.bvecs";
+    const char *path_data = "../bigann/bigann_base.bvecs";
+    snprintf(path_index, sizeof(path_index), "sift1b_%dm_ef_%d_M_%d.bin", subset_size_milllions, efConstruction, M);
 
-    sprintf(path_gt, "../bigann/gnd/idx_%dM.ivecs", subset_size_milllions);
+    snprintf(path_gt, sizeof(path_gt), "../bigann/gnd/idx_%dM.ivecs", subset_size_milllions);
 
     unsigned char *massb = new unsigned char[vecdim];
 

--- a/tests/cpp/updates_test.cpp
+++ b/tests/cpp/updates_test.cpp
@@ -239,7 +239,7 @@ int main(int argc, char **argv) {
         for (int b = 1; b < dummy_data_multiplier; b++) {
             std::cout << "Update iteration " << b << "\n";
             char cpath[1024];
-            sprintf(cpath, "batch_dummy_%02d.bin", b);
+            snprintf(cpath, sizeof(cpath), "batch_dummy_%02d.bin", b);
             std::vector<float> dummy_batchb = load_batch<float>(path + cpath, N * d);
 
             ParallelFor(0, N, num_threads, [&](size_t i, size_t threadId) {


### PR DESCRIPTION
`sprintf` is deprecated and not secure, since it doesn't protect against buffer overflows. Also, string literals are `const char*`, not `char*`.