### PR TITLE
[bruteforce] Fix bruteforce removePoint.

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -84,10 +84,16 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
 
 
     void removePoint(labeltype cur_external) {
-        size_t cur_c = dict_external_to_internal[cur_external];
+        std::unique_lock<std::mutex> lock(index_lock);
 
-        dict_external_to_internal.erase(cur_external);
+        auto found = dict_external_to_internal.find(cur_external);
+        if (found == dict_external_to_internal.end()) {
+            return;
+        }
 
+        dict_external_to_internal.erase(found);
+
+        size_t cur_c = found->second;
         labeltype label = *((labeltype*)(data_ + size_per_element_ * (cur_element_count-1) + data_size_));
         dict_external_to_internal[label] = cur_c;
         memcpy(data_ + size_per_element_ * cur_c,


### PR DESCRIPTION
Previous implementation was not thread-safe - unlike `addPoint` it didn't acquire an index lock.

While at it, this change also switches to `.find()` for cur_c lookups, so that following `erase` wouldn't have to perform another lookup.

P.S.: I don't see how `addPoint` is thread-safe as well, since write to data_ is performed outside of critical section, but oh well...