### PR TITLE
Check before removing march=native

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == 'darwin':
-        if platform.machine() == 'arm64':
+        if platform.machine() == 'arm64' and '-march=native' in c_opts['unix']:
             c_opts['unix'].remove('-march=native')
         c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
         link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']


### PR DESCRIPTION
If you set `HNSWLIB_NO_NATIVE` and build on Apple M1 the removal of `march=native` fails because it isn't in the list of arguments.