### PR TITLE
hnswalg.h: cap M to 100000

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -101,7 +101,13 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         data_size_ = s->get_data_size();
         fstdistfunc_ = s->get_dist_func();
         dist_func_param_ = s->get_dist_func_param();
-        M_ = M;
+        if ( M <= 100000 ) {
+            M_ = M;
+        } else {
+            std::cerr << "warning: M parameter exceeds 100000 which may lead to adverse effects." << std::endl;
+            std::cerr << "         Cap to 100000 will be applied for the rest of the processing." << std::endl;
+            M_ = 100000;
+        }
         maxM_ = M_;
         maxM0_ = M_ * 2;
         ef_construction_ = std::max(ef_construction, M_);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -101,12 +101,12 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         data_size_ = s->get_data_size();
         fstdistfunc_ = s->get_dist_func();
         dist_func_param_ = s->get_dist_func_param();
-        if ( M <= 100000 ) {
+        if ( M <= 10000 ) {
             M_ = M;
         } else {
-            std::cerr << "warning: M parameter exceeds 100000 which may lead to adverse effects." << std::endl;
-            std::cerr << "         Cap to 100000 will be applied for the rest of the processing." << std::endl;
-            M_ = 100000;
+            std::cerr << "warning: M parameter exceeds 10000 which may lead to adverse effects." << std::endl;
+            std::cerr << "         Cap to 10000 will be applied for the rest of the processing." << std::endl;
+            M_ = 10000;
         }
         maxM_ = M_;
         maxM0_ = M_ * 2;


### PR DESCRIPTION
This patch works around issue #467, also referenced as CVE-2023-37365, by implementing Yury Malkov's suggestion about capping the M value, coding the maximum number of outgoing connections in the graph, to a reasonable enough value of the order of 100000.  For the record, the documentation indicates reasonable values for M range from 2 to 100, which are well within the cap; see ALGO_PARAMS.md.

The reproducer shown in issue #467 doesn't trigger the double free condition anymore after this change is applied, but completes successfully, although with the below warning popping up on purpose:

	warning: M parameter exceeds 100000 which may lead to adverse effects.
	         Cap to 100000 will be applied for the rest of the processing.