### PR TITLE
Linking error fix

### DIFF
--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -15,7 +15,7 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #include <stdexcept>
-void cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
+static void cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
     __cpuidex(out, eax, ecx);
 }
 static __int64 xgetbv(unsigned int x) {


### PR DESCRIPTION
Fixes linking error when compiling with Visual Studio and including hnswlib.h in more than one cpp file.

before:
2>Tools.lib(Pch.obj) : error LNK2005: "void __cdecl cpuid(int * const,int,int)" (?cpuid@@YAXQEAHHH@Z) already defined in Pch.obj 2>Tools.lib(NearestNeighbors.obj) : error LNK2005: "void __cdecl cpuid(int * const,int,int)" (?cpuid@@YAXQEAHHH@Z) already defined in Pch.obj 2>C:\Users\Rade\Documents\Data Analysis\Code\GenomicsLab Repo\x64\Release\ExpressionDemo.exe : fatal error LNK1169: one or more multiply defined symbols found 2>Done building project "ExpressionDemo.vcxproj" -- FAILED.

after:
2>ExpressionDemo.vcxproj -> C:\Users\Rade\Documents\Data Analysis\Code\GenomicsLab Repo\x64\Release\ExpressionDemo.exe