### PR TITLE
Provide a macro to override the use of std::cerr

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -105,8 +105,8 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         if ( M <= 10000 ) {
             M_ = M;
         } else {
-            std::cerr << "warning: M parameter exceeds 10000 which may lead to adverse effects." << std::endl;
-            std::cerr << "         Cap to 10000 will be applied for the rest of the processing." << std::endl;
+            HNSWERR << "warning: M parameter exceeds 10000 which may lead to adverse effects." << std::endl;
+            HNSWERR << "         Cap to 10000 will be applied for the rest of the processing." << std::endl;
             M_ = 10000;
         }
         maxM_ = M_;

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -1,4 +1,11 @@
 #pragma once
+
+#ifndef HNSWLIB_ERR_OVERRIDE
+  #define HNSWERR std::cerr
+#else
+  #define HNSWERR HNSWLIB_ERR_OVERRIDE
+#endif
+
 #ifndef NO_MANUAL_VECTORIZATION
 #if (defined(__SSE__) || _M_IX86_FP > 0 || defined(_M_AMD64) || defined(_M_X64))
 #define USE_SSE

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// This allows others to provide their own error stream.
+// See RcppHNSW for a use case.
 #ifndef HNSWLIB_ERR_OVERRIDE
   #define HNSWERR std::cerr
 #else

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -1,7 +1,7 @@
 #pragma once
 
-// This allows others to provide their own error stream.
-// See RcppHNSW for a use case.
+// https://github.com/nmslib/hnswlib/pull/508
+// This allows others to provide their own error stream (e.g. RcppHNSW)
 #ifndef HNSWLIB_ERR_OVERRIDE
   #define HNSWERR std::cerr
 #else


### PR DESCRIPTION
#484 introduced a call to `std::cerr` when `M` is excessively large. This makes life hard for the [R bindings](https://github.com/jlmelville/rcpphnsw) because CRAN checks for and does not like to find anything writing to stdout/stderr (these streams should be sent to the console instead). Fortunately, the Rcpp library provides alternative streams (e.g. `Rcpp::Rcout` and `Rcpp::Rcerr`).

I propose using a macro to define the stream. By default this will be `std::cerr`, so users of this library need do nothing and will notice no changes. In RcppHNSW, I will create a header file which will declare the override, e.g.:

```C++
#include <Rcpp.h>

#define HNSWLIB_ERR_OVERRIDE Rcpp::Rcerr

#include "hnswlib.h"
```

A similar arrangement works for [Annoy](https://github.com/spotify/annoy/blob/2be37c9e015544be2cf60c431f0cccc076151a2d/src/annoylib.h#L76-L82C7) and [RcppAnnoy](https://github.com/eddelbuettel/rcppannoy/blob/cdaeeb83c01dae7a08b011c8c2304d8487435967/inst/include/RcppAnnoy.h#L21-L22).