### PR TITLE
Avoid sign mismatch in loop

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -792,7 +792,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         size_t dim = *((size_t *) dist_func_param_);
         std::vector<data_t> data;
         data_t* data_ptr = (data_t*) data_ptrv;
-        for (int i = 0; i < dim; i++) {
+        for (size_t i = 0; i < dim; i++) {
             data.push_back(*data_ptr);
             data_ptr += 1;
         }


### PR DESCRIPTION
GCC is complaining about different signedness in the loop which populates the return value in `getDataByLabel`:

```g++
warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
     795 |         for (int i = 0; i < dim; i++) {
```

The simplest fix, given here, is to change the type of the loop index `i` to `size_t`. A more idiomatic C++ approach would be to avoid introducing the loop in the first place, e.g.

```C++
std::copy(data_ptr, data_ptr + dim, std::back_inserter(data));
```

I checked that this worked (at least via the R bindings) but admittedly made no effort to do a proper performance check, so simpler is probably better.
