### PR TITLE
bug fix: In `bruteforce.h`, `searchKnn` return less element than expected when using filter.

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -108,7 +108,9 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
         assert(k <= cur_element_count);
         std::priority_queue<std::pair<dist_t, labeltype >> topResults;
         if (cur_element_count == 0) return topResults;
-        for (int i = 0; i < k; i++) {
+
+        int i = 0;
+        for (; topResults.size() < k && i < cur_element_count; i++) {
             dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
             labeltype label = *((labeltype*) (data_ + size_per_element_ * i + data_size_));
             if ((!isIdAllowed) || (*isIdAllowed)(label)) {
@@ -116,7 +118,7 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
             }
         }
         dist_t lastdist = topResults.empty() ? std::numeric_limits<dist_t>::max() : topResults.top().first;
-        for (int i = k; i < cur_element_count; i++) {
+        for (; i < cur_element_count; i++) {
             dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
             if (dist <= lastdist) {
                 labeltype label = *((labeltype *) (data_ + size_per_element_ * i + data_size_));


### PR DESCRIPTION
### Bug Description

This bug will occur when less than `k` elements are added into `topResults`, and the remaining elements all failed to satisfy `dist <= topResults.top().first`(Notice that `topResults.size() < k` now).

If there sure is `k` elements satisfy `dist <= topResults.top().first`, the function should return them regardless of their internal order.

### Example

When calling `searchKnn` with filter, the following code may cannot fill the `topResults` to size `k`.

```cpp
for (int i = 0; i < k; i++) {
    dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
    labeltype label = *((labeltype*) (data_ + size_per_element_ * i + data_size_));
    if ((!isIdAllowed) || (*isIdAllowed)(label)) { // <- not every element satisfies
        topResults.emplace(dist, label);
    }
}
```

If the above loop only fill **one nearest element** into `topResults`, the following loop will never satisfy `dist <= lastdist`, as `lastdist` is the nearest element. Under this circumstance, the function will only return 1 element regardless of `k`.

```cpp
// now topResults.size() == 1, and the only element in the container is the nearest element of all elements.
dist_t lastdist = topResults.empty() ? std::numeric_limits<dist_t>::max() : topResults.top().first;
for (int i = k; i < cur_element_count; i++) {
    dist_t dist = fstdistfunc_(query_data, data_ + size_per_element_ * i, dist_func_param_);
    if (dist <= lastdist) { // <- will never satisfy
        labeltype label = *((labeltype *) (data_ + size_per_element_ * i + data_size_));
        if ((!isIdAllowed) || (*isIdAllowed)(label)) {
            topResults.emplace(dist, label);
        }
        if (topResults.size() > k)
            topResults.pop();
        if (!topResults.empty()) {
            lastdist = topResults.top().first;
        }
    }
}
return topResults;
```
