### PR TITLE
Add seed property to Python Index

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -974,7 +974,9 @@ PYBIND11_PLUGIN(hnswlib) {
         .def_property_readonly("M",  [](const Index<float> & index) {
           return index.index_inited ? index.appr_alg->M_ : 0;
         })
-
+        .def_property_readonly("seed", [](const Index<float> & index) {
+          return index.seed;
+        })
         .def(py::pickle(
             [](const Index<float> &ind) {  // __getstate__
                 return py::make_tuple(ind.getIndexParams()); /* Return dict (wrapped in a tuple) that fully encodes state of the Index object */


### PR DESCRIPTION
With this PR, users of the Python library will now be able to view the random seed given an instance of Index. 