### PR TITLE
add seed property

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -974,7 +974,9 @@ PYBIND11_PLUGIN(hnswlib) {
         .def_property_readonly("M",  [](const Index<float> & index) {
           return index.index_inited ? index.appr_alg->M_ : 0;
         })
-
+        .def_property_readonly("seed", [](const Index<float> & index) {
+          return index.seed;
+        })
         .def(py::pickle(
             [](const Index<float> &ind) {  // __getstate__
                 return py::make_tuple(ind.getIndexParams()); /* Return dict (wrapped in a tuple) that fully encodes state of the Index object */


### PR DESCRIPTION
I was migrating to https://github.com/djc/instant-distance during a Python to Rust migration and needed the seed values to run comparison tests. I assume others may want access to their seed value if they did not originally create the Index.