### PR TITLE
Fix setuptools.distutils import for Python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def has_flag(compiler, flagname):
         f.write('int main (int argc, char **argv) { return 0; }')
         try:
             compiler.compile([f.name], extra_postargs=[flagname])
-        except setuptools.distutils.errors.CompileError:
+        except Exception:
             return False
     return True
 


### PR DESCRIPTION
The setuptools.distutils.errors.CompileError import path is broken on
Python 3.12+ where setuptools no longer exposes the distutils subpackage
at the old path. Replace with a broad Exception catch which handles
CompileError regardless of setuptools version.

Signed-off-by: Emilien Macchi <emacchi@redhat.com>
