### PR TITLE
feat: add get_memory_usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,4 +77,5 @@ jobs:
           ./test_updates update
           ./multivector_search_test
           ./epsilon_search_test
+          ./memory_usage_test
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,9 @@ if(HNSWLIB_EXAMPLES)
     add_executable(multiThread_replace_test tests/cpp/multiThread_replace_test.cpp)
     target_link_libraries(multiThread_replace_test hnswlib)
 
+    add_executable(memory_usage_test tests/cpp/memory_usage_test.cpp)
+    target_link_libraries(memory_usage_test hnswlib)
+
     add_executable(main tests/cpp/main.cpp tests/cpp/sift_1b.cpp)
     target_link_libraries(main hnswlib)
 endif()

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ For other spaces use the nmslib library https://github.com/nmslib/nmslib.
 
 * `get_current_count()` - returns the current number of element stored in the index
 
+* `get_memory_usage()` - returns approximate bytes used by the in-memory graph
+
 Read-only properties of `hnswlib.Index` class:
 
 * `space` - name of the space (can be one of "l2", "ip", or "cosine"). 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -682,6 +682,19 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         return size;
     }
 
+    size_t getMemoryUsage() const {
+        size_t size = 0;
+        size += max_elements_ * size_data_per_element_;
+        size += max_elements_ * sizeof(void *);
+        size += element_levels_.size() * sizeof(int);
+        for (size_t i = 0; i < cur_element_count; i++) {
+            if (element_levels_[i] > 0) {
+                size += size_links_per_element_ * element_levels_[i] + 1;
+            }
+        }
+        return size;
+    }
+
     void saveIndex(const std::string &location) {
         std::ofstream output(location, std::ios::binary);
         std::streampos position;

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -222,6 +222,10 @@ class Index {
         return appr_alg->indexFileSize();
     }
 
+    size_t getMemoryUsage() const {
+        return appr_alg->getMemoryUsage();
+    }
+
     void saveIndex(const std::string &path_to_index) {
         appr_alg->saveIndex(path_to_index);
     }
@@ -939,6 +943,7 @@ PYBIND11_PLUGIN(hnswlib) {
         .def("set_ef", &Index<float>::set_ef, py::arg("ef"))
         .def("set_num_threads", &Index<float>::set_num_threads, py::arg("num_threads"))
         .def("index_file_size", &Index<float>::indexFileSize)
+        .def("get_memory_usage", &Index<float>::getMemoryUsage)
         .def("save_index", &Index<float>::saveIndex, py::arg("path_to_index"))
         .def("load_index",
             &Index<float>::loadIndex,

--- a/tests/cpp/memory_usage_test.cpp
+++ b/tests/cpp/memory_usage_test.cpp
@@ -1,0 +1,38 @@
+#include "assert.h"
+#include "../../hnswlib/hnswlib.h"
+#include <random>
+#include <vector>
+
+int main() {
+    int dim = 16;
+    int max_elements = 1000;
+    int M = 16;
+    int ef_construction = 200;
+
+    hnswlib::L2Space space(dim);
+    hnswlib::HierarchicalNSW<float>* alg_hnsw = new hnswlib::HierarchicalNSW<float>(&space, max_elements, M, ef_construction, 42);
+
+    size_t mem_before = alg_hnsw->getMemoryUsage();
+    size_t file_before = alg_hnsw->indexFileSize();
+    assert(mem_before > 0);
+    assert(mem_before >= file_before);
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> distrib(0.0f, 1.0f);
+    std::vector<float> data(dim * max_elements);
+    for (size_t i = 0; i < data.size(); i++) {
+        data[i] = distrib(rng);
+    }
+    for (int i = 0; i < max_elements; i++) {
+        alg_hnsw->addPoint(data.data() + (i * dim), i);
+    }
+
+    size_t mem_after = alg_hnsw->getMemoryUsage();
+    size_t file_after = alg_hnsw->indexFileSize();
+    assert(mem_after > 0);
+    assert(mem_after >= mem_before);
+    assert(mem_after >= file_after);
+
+    delete alg_hnsw;
+    return 0;
+}

--- a/tests/python/bindings_test_metadata.py
+++ b/tests/python/bindings_test_metadata.py
@@ -47,3 +47,20 @@ class RandomSelfTestCase(unittest.TestCase):
         self.assertEqual(p.ef_construction, 100)
         self.assertEqual(p.max_elements, num_elements)
         self.assertEqual(p.element_count, num_elements)
+
+    def testMemoryUsage(self):
+        dim = 8
+        num_elements = 1000
+        data = np.float32(np.random.random((num_elements, dim)))
+
+        p = hnswlib.Index(space='l2', dim=dim)
+        p.init_index(max_elements=num_elements, ef_construction=100, M=16)
+
+        usage_before = p.get_memory_usage()
+        p.add_items(data)
+        usage_after = p.get_memory_usage()
+
+        self.assertGreater(usage_before, 0)
+        self.assertGreater(usage_after, 0)
+        self.assertGreaterEqual(usage_after, usage_before)
+        self.assertGreaterEqual(usage_after, p.index_file_size())


### PR DESCRIPTION
## Summary

Resolved the issue #648 .

- Add approximate in-memory graph usage reporting to HNSW indexes.

Changes

- Add HierarchicalNSW::getMemoryUsage() and expose it as Index.get_memory_usage() in Python.
- Add Python unit test for get_memory_usage .
- Add C++ unit test ( memory_usage_test ) and register it in CMake.
- Update README and CI workflow to include the new test.

## Testing

- python -m unittest discover --start-directory tests/python --pattern "bindings_test*.py"
- mkdir -p build && cd build && cmake .. && make memory_usage_test && ./memory_usage_test