### PR TITLE
Feat: Add optional no_deleted flag to get_ids_list in Python bindings

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -339,16 +339,17 @@ class Index {
         }
     }
 
-
-    std::vector<hnswlib::labeltype> getIdsList() {
+    std::vector<hnswlib::labeltype> getIdsList(bool no_deleted = false) {
         std::vector<hnswlib::labeltype> ids;
 
         for (auto kv : appr_alg->label_lookup_) {
+            if (no_deleted && appr_alg->isMarkedDeleted(kv.second)) {
+                continue;
+            }
             ids.push_back(kv.first);
         }
         return ids;
     }
-
 
     py::dict getAnnData() const { /* WARNING: Index::getAnnData is not thread-safe with Index::addItems */
         std::unique_lock <std::mutex> templock(appr_alg->global);
@@ -960,7 +961,7 @@ PYBIND11_PLUGIN(hnswlib) {
             py::arg("num_threads") = -1,
             py::arg("replace_deleted") = false)
         .def("get_items", &Index<float>::getData, py::arg("ids") = py::none(), py::arg("return_type") = "numpy")
-        .def("get_ids_list", &Index<float>::getIdsList)
+        .def("get_ids_list", &Index<float>::getIdsList, py::arg("no_deleted") = false)
         .def("set_ef", &Index<float>::set_ef, py::arg("ef"))
         .def("set_num_threads", &Index<float>::set_num_threads, py::arg("num_threads"))
         .def("index_file_size", &Index<float>::indexFileSize)

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -341,13 +341,20 @@ class Index {
 
     std::vector<hnswlib::labeltype> getIdsList(bool no_deleted = false) {
         std::vector<hnswlib::labeltype> ids;
-
-        for (auto kv : appr_alg->label_lookup_) {
-            if (no_deleted && appr_alg->isMarkedDeleted(kv.second)) {
-                continue;
+        if (no_deleted) {
+            for (auto kv : appr_alg->label_lookup_) {
+                
+                if (appr_alg->isMarkedDeleted(kv.second)) {
+                    continue;
+                }
+                ids.push_back(kv.first);
+            }     
+        } else {
+            for (auto kv : appr_alg->label_lookup_) {
+                ids.push_back(kv.first);
             }
-            ids.push_back(kv.first);
         }
+            
         return ids;
     }
 


### PR DESCRIPTION
Added an optional `no_deleted` flag to `get_ids_list` to allow filtering of tombstones.

## Issue
I use the python bindings and need to periodically clean up the index. One way to do this is by recreating the index without the tombstoned items. Currently, `get_ids_list` returns all labels, including deleted ones. Calling `get_items` on this list triggers a `RuntimeError: Label not found` when it hits a deleted element.

The only way to recreate the index without the deleted items is by using a try-except loop.
```py
# The current, slow workaround:
active_ids = []
for doc_id in index.get_ids_list():
    try:
        index.get_items([doc_id])
        active_ids.append(doc_id)
    except RuntimeError:
        pass # Skip deleted items
```

## Result
This fix let's us safely bulk-fetch active data without the slow, one-by-one try-except loops:
```py
new_index = hnswlib.Index(space=old_index.space, dim=old_index.dim)

new_index.init_index(
    max_elements=old_index.max_elements,
    M=old_index.M,
    ef_construction=old_index.ef_construction
)

active_ids = old_index.get_ids_list(no_deleted=True)
new_index.add_items(old_index.get_items(active_ids), active_ids)
```