### PR TITLE
ci: update actions/checkout to v6 and actions/setup-python to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
         os: [ubuntu, windows, macos]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.2"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -65,8 +65,8 @@ jobs:
           - os: macos
             compiler: gcc
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Updated version of actions to fix the  https://github.com/nmslib/hnswlib/issues/654 