### PR TITLE
Added the NEON implementation for distance calculation and added the corresponding UT test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,29 @@ target_include_directories(hnswlib INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+# AArch64 NEON dot-product kernels (space_ip.h / space_l2.h): only active when
+# USE_NEON is defined; requires -march=armv8.2-a+dotprod on GCC/Clang for ARM.
+option(USE_NEON "Enable AArch64 NEON dot-product distance functions (defines USE_NEON)" OFF)
+
+set(HNSWLIB_IS_AARCH64 FALSE)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|AARCH64|arm64|ARM64)$")
+    set(HNSWLIB_IS_AARCH64 TRUE)
+endif()
+
+if(USE_NEON)
+    target_compile_definitions(hnswlib INTERFACE USE_NEON)
+    if(HNSWLIB_IS_AARCH64)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+            target_compile_options(hnswlib INTERFACE
+                $<$<COMPILE_LANGUAGE:CXX>:-march=armv8.2-a+dotprod>)
+        endif()
+    else()
+        message(WARNING
+            "USE_NEON is ON but CMAKE_SYSTEM_PROCESSOR is '${CMAKE_SYSTEM_PROCESSOR}' "
+            "(not AArch64). NEON code may not compile on this platform.")
+    endif()
+endif()
+
 # Install
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/hnswlib
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -150,15 +173,19 @@ if(HNSWLIB_EXAMPLES)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         # We enable optimizations in all build types, even in Debug.
         add_cxx_flags(-O3 -ffast-math -openmp -ftree-vectorize)
-        check_cxx_compiler_flag("-march=native" COMPILER_SUPPORT_NATIVE_FLAG)
-        if(COMPILER_SUPPORT_NATIVE_FLAG)
-            add_cxx_flags(-march=native)
-            message("set -march=native flag")
-        else()
-            check_cxx_compiler_flag("-mcpu=apple-m1" COMPILER_SUPPORT_M1_FLAG)
-            if(COMPILER_SUPPORT_M1_FLAG)
-                add_cxx_flags(-mcpu=apple-m1)
-                message("set -mcpu=apple-m1 flag")
+        # USE_NEON pulls -march=armv8.2-a+dotprod from the hnswlib INTERFACE;
+        # avoid -march=native here so it does not override dotprod.
+        if(NOT (USE_NEON AND HNSWLIB_IS_AARCH64))
+            check_cxx_compiler_flag("-march=native" COMPILER_SUPPORT_NATIVE_FLAG)
+            if(COMPILER_SUPPORT_NATIVE_FLAG)
+                add_cxx_flags(-march=native)
+                message("set -march=native flag")
+            else()
+                check_cxx_compiler_flag("-mcpu=apple-m1" COMPILER_SUPPORT_M1_FLAG)
+                if(COMPILER_SUPPORT_M1_FLAG)
+                    add_cxx_flags(-mcpu=apple-m1)
+                    message("set -mcpu=apple-m1 flag")
+                endif()
             endif()
         endif()
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -167,6 +194,9 @@ if(HNSWLIB_EXAMPLES)
       if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|powerpc")
         add_cxx_flags(-mtune=native)
         message("set -mtune=native flag")
+      elseif(USE_NEON AND HNSWLIB_IS_AARCH64)
+        # -march=armv8.2-a+dotprod comes from hnswlib INTERFACE when USE_NEON is ON.
+        message("Skipping -march=native on AArch64 with USE_NEON (using INTERFACE -march=armv8.2-a+dotprod)")
       else()
         add_cxx_flags(-march=native)
         message("set -march=native flag")
@@ -243,6 +273,11 @@ if(HNSWLIB_EXAMPLES)
 
     # This test deviates from the above pattern of naming test executables.
     add_example_or_test(test_updates tests/cpp/updates_test.cpp)
+
+    # NEON distance test: only when USE_NEON and AArch64 (NEON intrinsics required).
+    if(USE_NEON AND HNSWLIB_IS_AARCH64)
+        add_example_or_test(distance_calculation_neon_test tests/cpp/distance_calculation_neon.cpp)
+    endif()
 
     # For historical reasons, the "main" program links with sift_1b.cpp.
     add_example_or_test(main tests/cpp/main.cpp tests/cpp/sift_1b.cpp)

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -1,5 +1,15 @@
+/* NEON vectorized distance calculation is supported.
+ *
+ * Copyright 2026 Huawei Technologies Co., Ltd.
+ */
+
 #pragma once
 #include "hnswlib.h"
+#ifdef USE_NEON
+#include "arm_neon.h"
+#endif
+
+
 
 namespace hnswlib {
 
@@ -158,7 +168,7 @@ InnerProductSIMD16ExtAVX512(const void *pVect1v, const void *pVect2v, const void
     __m512 sum512 = _mm512_set1_ps(0);
 
     size_t loop = qty16 / 4;
-
+    
     while (loop--) {
         __m512 v1 = _mm512_loadu_ps(pVect1);
         __m512 v2 = _mm512_loadu_ps(pVect2);
@@ -339,6 +349,120 @@ InnerProductDistanceSIMD4ExtResiduals(const void *pVect1v, const void *pVect2v, 
 }
 #endif
 
+#if defined(USE_NEON)
+
+static float
+InnerProductSIMD16ExtNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    float *x = (float *) pVect1v;
+    float *y = (float *) pVect2v;
+    size_t qty = *((size_t *) qty_ptr);
+
+    size_t i;
+    float res;
+    constexpr size_t single_round = 16;
+
+    float32x4_t x4_0 = vld1q_f32(x);
+    float32x4_t x4_1 = vld1q_f32(x + 4);
+    float32x4_t x4_2 = vld1q_f32(x + 8);
+    float32x4_t x4_3 = vld1q_f32(x + 12);
+
+    float32x4_t y4_0 = vld1q_f32(y);
+    float32x4_t y4_1 = vld1q_f32(y + 4);
+    float32x4_t y4_2 = vld1q_f32(y + 8);
+    float32x4_t y4_3 = vld1q_f32(y + 12);
+
+    float32x4_t d4_0 = vmulq_f32(x4_0, y4_0);
+    float32x4_t d4_1 = vmulq_f32(x4_1, y4_1);
+    float32x4_t d4_2 = vmulq_f32(x4_2, y4_2);
+    float32x4_t d4_3 = vmulq_f32(x4_3, y4_3);
+
+    for (i = single_round; i <= qty - single_round; i += single_round) {
+        x4_0 = vld1q_f32(x + i);
+        y4_0 = vld1q_f32(y + i);
+        d4_0 = vmlaq_f32(d4_0, x4_0, y4_0);
+
+        x4_1 = vld1q_f32(x + i + 4);
+        y4_1 = vld1q_f32(y + i + 4);
+        d4_1 = vmlaq_f32(d4_1, x4_1, y4_1);
+
+        x4_2 = vld1q_f32(x + i + 8);
+        y4_2 = vld1q_f32(y + i + 8);
+        d4_2 = vmlaq_f32(d4_2, x4_2, y4_2);
+
+        x4_3 = vld1q_f32(x + i + 12);
+        y4_3 = vld1q_f32(y + i + 12);
+        d4_3 = vmlaq_f32(d4_3, x4_3, y4_3);
+    }
+
+    d4_0 = vaddq_f32(d4_0, d4_1);
+    d4_2 = vaddq_f32(d4_2, d4_3);
+    d4_0 = vaddq_f32(d4_0, d4_2);
+    res = vaddvq_f32(d4_0);
+
+    return (res);
+}
+
+static float
+InnerProductDistanceSIMD16ExtNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    return 1.0f - InnerProductSIMD16ExtNEON(pVect1v, pVect2v, qty_ptr);
+}
+
+static float
+InnerProductSIMD4ExtNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    float *x = (float *) pVect1v;
+    float *y = (float *) pVect2v;
+    size_t qty = *((size_t *) qty_ptr);
+
+    size_t i;
+    float res;
+    constexpr size_t single_round = 4;
+
+    float32x4_t x4_0 = vld1q_f32(x);
+    float32x4_t y4_0 = vld1q_f32(y);
+    float32x4_t d4_0 = vmulq_f32(x4_0, y4_0);
+
+    for (i = single_round; i <= qty - single_round; i += single_round) {
+        x4_0 = vld1q_f32(x + i);
+        y4_0 = vld1q_f32(y + i);
+        d4_0 = vmlaq_f32(d4_0, x4_0, y4_0);
+    }
+    res = vaddvq_f32(d4_0);
+
+    return (res);
+}
+
+static float
+InnerProductDistanceSIMD4ExtNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    return 1.0f - InnerProductSIMD4ExtNEON(pVect1v, pVect2v, qty_ptr);
+}
+
+static float
+InnerProductDistanceSIMD16ExtResidualsNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    size_t qty = *((size_t *) qty_ptr);
+    size_t qty16 = qty >> 4 << 4;
+    float res_16 = InnerProductSIMD16ExtNEON(pVect1v, pVect2v, &qty16);
+    
+    size_t qty_left = qty - qty16;
+    float *pVect1 = (float *) pVect1v + qty16;
+    float *pVect2 = (float *) pVect2v + qty16;
+    float res_tail = InnerProduct(pVect1, pVect2, &qty_left);
+    return 1.0f - (res_16 + res_tail);
+}
+
+static float
+InnerProductDistanceSIMD4ExtResidualsNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    size_t qty = *((size_t *) qty_ptr);
+    size_t qty4 = qty >> 2 << 2;
+    float res = InnerProductSIMD4ExtNEON(pVect1v, pVect2v, &qty4);
+
+    size_t qty_left = qty - qty4;
+    float *pVect1 = (float *) pVect1v + qty4;
+    float *pVect2 = (float *) pVect2v + qty4;
+    float res_tail = InnerProduct(pVect1, pVect2, &qty_left);
+    return 1.0f - (res + res_tail);
+}
+#endif
+
 class InnerProductSpace : public SpaceInterface<float> {
     DISTFUNC<float> fstdistfunc_;
     size_t data_size_;
@@ -347,7 +471,7 @@ class InnerProductSpace : public SpaceInterface<float> {
  public:
     InnerProductSpace(size_t dim) {
         fstdistfunc_ = InnerProductDistance;
-#if defined(USE_AVX) || defined(USE_SSE) || defined(USE_AVX512)
+#if defined(USE_AVX) || defined(USE_SSE) || defined(USE_AVX512) || defined(USE_NEON)
     #if defined(USE_AVX512)
         if (AVX512Capable()) {
             InnerProductSIMD16Ext = InnerProductSIMD16ExtAVX512;
@@ -369,6 +493,16 @@ class InnerProductSpace : public SpaceInterface<float> {
         }
     #endif
 
+    #if defined(USE_NEON)
+        if (dim > 0 && dim % 16 == 0)
+            fstdistfunc_ = InnerProductDistanceSIMD16ExtNEON;
+        else if (dim % 4 == 0)
+            fstdistfunc_ = InnerProductDistanceSIMD4ExtNEON;
+        else if (dim > 16)
+            fstdistfunc_ = InnerProductDistanceSIMD16ExtResidualsNEON;
+        else if (dim > 4)
+            fstdistfunc_ = InnerProductDistanceSIMD4ExtResidualsNEON;
+    #else
         if (dim % 16 == 0)
             fstdistfunc_ = InnerProductDistanceSIMD16Ext;
         else if (dim % 4 == 0)
@@ -377,6 +511,7 @@ class InnerProductSpace : public SpaceInterface<float> {
             fstdistfunc_ = InnerProductDistanceSIMD16ExtResiduals;
         else if (dim > 4)
             fstdistfunc_ = InnerProductDistanceSIMD4ExtResiduals;
+    #endif
 #endif
         dim_ = dim;
         data_size_ = dim * sizeof(float);

--- a/hnswlib/space_ip.h
+++ b/hnswlib/space_ip.h
@@ -1,8 +1,3 @@
-/* NEON vectorized distance calculation is supported.
- *
- * Copyright 2026 Huawei Technologies Co., Ltd.
- */
-
 #pragma once
 #include "hnswlib.h"
 #ifdef USE_NEON

--- a/hnswlib/space_l2.h
+++ b/hnswlib/space_l2.h
@@ -1,5 +1,13 @@
+/* NEON vectorized distance calculation is supported.
+ *
+ * Copyright 2026 Huawei Technologies Co., Ltd.
+ */
+
 #pragma once
 #include "hnswlib.h"
+#ifdef USE_NEON
+#include "arm_neon.h"
+#endif
 
 namespace hnswlib {
 
@@ -205,6 +213,122 @@ L2SqrSIMD4ExtResiduals(const void *pVect1v, const void *pVect2v, const void *qty
 }
 #endif
 
+#if defined(USE_NEON)
+
+static float
+L2SqrSIMD16ExtNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    float *x = (float *) pVect1v;
+    float *y = (float *) pVect2v;
+    size_t qty = *((size_t *) qty_ptr);
+
+    size_t i;
+    float res;
+    constexpr size_t single_round = 16;
+
+    
+    float32x4_t x4_0 = vld1q_f32(x);
+    float32x4_t x4_1 = vld1q_f32(x + 4);
+    float32x4_t x4_2 = vld1q_f32(x + 8);
+    float32x4_t x4_3 = vld1q_f32(x + 12);
+
+    float32x4_t y4_0 = vld1q_f32(y);
+    float32x4_t y4_1 = vld1q_f32(y + 4);
+    float32x4_t y4_2 = vld1q_f32(y + 8);
+    float32x4_t y4_3 = vld1q_f32(y + 12);
+
+    float32x4_t q4_0 = vsubq_f32(x4_0, y4_0);
+    float32x4_t q4_1 = vsubq_f32(x4_1, y4_1);
+    float32x4_t q4_2 = vsubq_f32(x4_2, y4_2);
+    float32x4_t q4_3 = vsubq_f32(x4_3, y4_3);
+
+    float32x4_t d4_0 = vmulq_f32(q4_0, q4_0);
+    float32x4_t d4_1 = vmulq_f32(q4_1, q4_1);
+    float32x4_t d4_2 = vmulq_f32(q4_2, q4_2);
+    float32x4_t d4_3 = vmulq_f32(q4_3, q4_3);
+
+    for (i = single_round; i <= qty - single_round; i += single_round) {
+        x4_0 = vld1q_f32(x + i);
+        x4_1 = vld1q_f32(x + i + 4);
+        x4_2 = vld1q_f32(x + i + 8);
+        x4_3 = vld1q_f32(x + i + 12);
+
+        y4_0 = vld1q_f32(y + i);
+        y4_1 = vld1q_f32(y + i + 4);
+        y4_2 = vld1q_f32(y + i + 8);
+        y4_3 = vld1q_f32(y + i + 12);
+
+        q4_0 = vsubq_f32(x4_0, y4_0);
+        q4_1 = vsubq_f32(x4_1, y4_1);
+        q4_2 = vsubq_f32(x4_2, y4_2);
+        q4_3 = vsubq_f32(x4_3, y4_3);
+
+        d4_0 = vmlaq_f32(d4_0, q4_0, q4_0);
+        d4_1 = vmlaq_f32(d4_1, q4_1, q4_1);
+        d4_2 = vmlaq_f32(d4_2, q4_2, q4_2);
+        d4_3 = vmlaq_f32(d4_3, q4_3, q4_3);
+    }
+
+    d4_0 = vaddq_f32(d4_0, d4_1);
+    d4_2 = vaddq_f32(d4_2, d4_3);
+    d4_0 = vaddq_f32(d4_0, d4_2);
+    res = vaddvq_f32(d4_0);
+
+    return (res);
+}
+
+static float
+L2SqrSIMD4ExtNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    float *x = (float *) pVect1v;
+    float *y = (float *) pVect2v;
+    size_t qty = *((size_t *) qty_ptr);
+
+    size_t i;
+    float res;
+    constexpr size_t single_round = 4;
+
+    float32x4_t x4_0 = vld1q_f32(x);
+    float32x4_t y4_0 = vld1q_f32(y);
+    float32x4_t q4_0 = vsubq_f32(x4_0, y4_0);
+    float32x4_t d4_0 = vmulq_f32(q4_0, q4_0);
+
+    for (i = single_round; i <= qty - single_round; i += single_round) {
+        x4_0 = vld1q_f32(x + i);
+        y4_0 = vld1q_f32(y + i);
+        q4_0 = vsubq_f32(x4_0, y4_0);
+        d4_0 = vmlaq_f32(d4_0, q4_0, q4_0);
+    }
+    res = vaddvq_f32(d4_0);
+
+    return (res);
+}
+
+static float
+L2SqrSIMD16ExtResidualsNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    size_t qty = *((size_t *) qty_ptr);
+    size_t qty16 = qty >> 4 << 4;
+    float res_16 = L2SqrSIMD16ExtNEON(pVect1v, pVect2v, &qty16);
+    
+    size_t qty_left = qty - qty16;
+    float *pVect1 = (float *) pVect1v + qty16;
+    float *pVect2 = (float *) pVect2v + qty16;
+    float res_tail = L2Sqr(pVect1, pVect2, &qty_left);
+    return (res_16 + res_tail);
+}
+
+static float
+L2SqrSIMD4ExtResidualsNEON(const void *pVect1v, const void *pVect2v, const void *qty_ptr) {
+    size_t qty = *((size_t *) qty_ptr);
+    size_t qty4 = qty >> 2 << 2;
+    float res = L2SqrSIMD4ExtNEON(pVect1v, pVect2v, &qty4);
+
+    size_t qty_left = qty - qty4;
+    float *pVect1 = (float *) pVect1v + qty4;
+    float *pVect2 = (float *) pVect2v + qty4;
+    float res_tail = L2Sqr(pVect1, pVect2, &qty_left);
+    return (res + res_tail);
+}
+#endif
+
 class L2Space : public SpaceInterface<float> {
     DISTFUNC<float> fstdistfunc_;
     size_t data_size_;
@@ -213,7 +337,7 @@ class L2Space : public SpaceInterface<float> {
  public:
     L2Space(size_t dim) {
         fstdistfunc_ = L2Sqr;
-#if defined(USE_SSE) || defined(USE_AVX) || defined(USE_AVX512)
+#if defined(USE_SSE) || defined(USE_AVX) || defined(USE_AVX512) || defined(USE_NEON)
     #if defined(USE_AVX512)
         if (AVX512Capable())
             L2SqrSIMD16Ext = L2SqrSIMD16ExtAVX512;
@@ -224,6 +348,16 @@ class L2Space : public SpaceInterface<float> {
             L2SqrSIMD16Ext = L2SqrSIMD16ExtAVX;
     #endif
 
+    #if defined(USE_NEON)
+        if (dim > 0 && dim % 16 == 0)
+            fstdistfunc_ = L2SqrSIMD16ExtNEON;
+        else if (dim % 4 == 0)
+            fstdistfunc_ = L2SqrSIMD4ExtNEON;
+        else if (dim > 16)
+            fstdistfunc_ = L2SqrSIMD16ExtResidualsNEON;
+        else if (dim > 4)
+            fstdistfunc_ = L2SqrSIMD4ExtResidualsNEON;
+    #else
         if (dim % 16 == 0)
             fstdistfunc_ = L2SqrSIMD16Ext;
         else if (dim % 4 == 0)
@@ -232,6 +366,7 @@ class L2Space : public SpaceInterface<float> {
             fstdistfunc_ = L2SqrSIMD16ExtResiduals;
         else if (dim > 4)
             fstdistfunc_ = L2SqrSIMD4ExtResiduals;
+    #endif
 #endif
         dim_ = dim;
         data_size_ = dim * sizeof(float);

--- a/hnswlib/space_l2.h
+++ b/hnswlib/space_l2.h
@@ -1,8 +1,3 @@
-/* NEON vectorized distance calculation is supported.
- *
- * Copyright 2026 Huawei Technologies Co., Ltd.
- */
-
 #pragma once
 #include "hnswlib.h"
 #ifdef USE_NEON

--- a/hnswlib/stop_condition.h
+++ b/hnswlib/stop_condition.h
@@ -1,8 +1,3 @@
-/* NEON vectorized distance calculation is supported.
- *
- * Copyright 2026 Huawei Technologies Co., Ltd.
- */
-
 #pragma once
 #include "space_l2.h"
 #include "space_ip.h"

--- a/hnswlib/stop_condition.h
+++ b/hnswlib/stop_condition.h
@@ -1,3 +1,8 @@
+/* NEON vectorized distance calculation is supported.
+ *
+ * Copyright 2026 Huawei Technologies Co., Ltd.
+ */
+
 #pragma once
 #include "space_l2.h"
 #include "space_ip.h"
@@ -36,6 +41,16 @@ class MultiVectorL2Space : public BaseMultiVectorSpace<DOCIDTYPE> {
             L2SqrSIMD16Ext = L2SqrSIMD16ExtAVX;
     #endif
 
+    #if defined(USE_NEON)
+        if (dim % 16 == 0)
+            fstdistfunc_ = L2SqrSIMD16ExtNEON;
+        else if (dim % 4 == 0)
+            fstdistfunc_ = L2SqrSIMD4ExtNEON;
+        else if (dim > 16)
+            fstdistfunc_ = L2SqrSIMD16ExtResidualsNEON;
+        else if (dim > 4)
+            fstdistfunc_ = L2SqrSIMD4ExtResidualsNEON;
+    #else
         if (dim % 16 == 0)
             fstdistfunc_ = L2SqrSIMD16Ext;
         else if (dim % 4 == 0)
@@ -44,6 +59,7 @@ class MultiVectorL2Space : public BaseMultiVectorSpace<DOCIDTYPE> {
             fstdistfunc_ = L2SqrSIMD16ExtResiduals;
         else if (dim > 4)
             fstdistfunc_ = L2SqrSIMD4ExtResiduals;
+    #endif
 #endif
         dim_ = dim;
         vector_size_ = dim * sizeof(float);
@@ -106,6 +122,16 @@ class MultiVectorInnerProductSpace : public BaseMultiVectorSpace<DOCIDTYPE> {
         }
     #endif
 
+    #if defined(USE_NEON)
+        if (dim % 16 == 0)
+            fstdistfunc_ = InnerProductDistanceSIMD16ExtNEON;
+        else if (dim % 4 == 0)
+            fstdistfunc_ = InnerProductDistanceSIMD4ExtNEON;
+        else if (dim > 16)
+            fstdistfunc_ = InnerProductDistanceSIMD16ExtResidualsNEON;
+        else if (dim > 4)
+            fstdistfunc_ = InnerProductDistanceSIMD4ExtResidualsNEON;
+    #else
         if (dim % 16 == 0)
             fstdistfunc_ = InnerProductDistanceSIMD16Ext;
         else if (dim % 4 == 0)
@@ -114,6 +140,7 @@ class MultiVectorInnerProductSpace : public BaseMultiVectorSpace<DOCIDTYPE> {
             fstdistfunc_ = InnerProductDistanceSIMD16ExtResiduals;
         else if (dim > 4)
             fstdistfunc_ = InnerProductDistanceSIMD4ExtResiduals;
+    #endif
 #endif
         vector_size_ = dim * sizeof(float);
         data_size_ = vector_size_ + sizeof(DOCIDTYPE);

--- a/tests/cpp/distance_calculation_neon.cpp
+++ b/tests/cpp/distance_calculation_neon.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Huawei Technologies Co., Ltd.
+ */
+
+#include <cstring>
+#include <vector>
+#include <cmath>
+#include "../../hnswlib/hnswlib.h"
+
+using namespace hnswlib;
+
+std::vector<float> generate_random_vector(size_t n, float min = -1.0f, float max = 1.0f)
+{
+    std::vector<float> vec(n);
+    for (size_t i = 0; i < n; ++i) {
+        float val = min + static_cast<float>(rand()) / RAND_MAX * (max - min);
+        vec[i] = val;
+    }
+    return vec;
+}
+
+bool run_distance_ip_test(size_t N) {
+    auto vec1 = generate_random_vector(N);
+    auto vec2 = generate_random_vector(N);
+
+    size_t qty = N;
+    float expected = InnerProductDistance(vec1.data(), vec2.data(), &qty);
+
+    float result = 0;
+    if (N % 16 == 0) {
+        result = InnerProductDistanceSIMD16ExtNEON(vec1.data(), vec2.data(), &qty);
+    } else if (N % 4 == 0) {
+        result = InnerProductDistanceSIMD4ExtNEON(vec1.data(), vec2.data(), &qty);
+    } else if (N > 16) {
+        result = InnerProductDistanceSIMD16ExtResidualsNEON(vec1.data(), vec2.data(), &qty);
+    } else if (N > 4) {
+        result = InnerProductDistanceSIMD4ExtResidualsNEON(vec1.data(), vec2.data(), &qty);
+    } else {
+        result = InnerProductDistance(vec1.data(), vec2.data(), &qty);
+    }
+
+    float diff = std::fabs(result - expected);
+    if (diff > 1e-4f) {
+        std::cout << "[FAIL] InnerProduct test for N=" << N 
+                  << " | Result: " << result 
+                  << " | Expected: " << expected 
+                  << " | Diff: " << diff << std::endl;
+        return false;
+    } else {
+        std::cout << "[PASS] InnerProduct test for N=" << N << std::endl;
+        return true;
+    }
+}
+
+
+bool run_distance_l2_test(size_t N) {
+    auto vec1 = generate_random_vector(N);
+    auto vec2 = generate_random_vector(N);
+
+    size_t qty = N;
+    float expected = L2Sqr(vec1.data(), vec2.data(), &qty);
+
+    float result = 0;
+    if (N % 16 == 0) {
+        result = L2SqrSIMD16ExtNEON(vec1.data(), vec2.data(), &qty);
+    } else if (N % 4 == 0) {
+        result = L2SqrSIMD4ExtNEON(vec1.data(), vec2.data(), &qty);
+    } else if (N > 16) {
+        result = L2SqrSIMD16ExtResidualsNEON(vec1.data(), vec2.data(), &qty);
+    } else if (N > 4) {
+        result = L2SqrSIMD4ExtResidualsNEON(vec1.data(), vec2.data(), &qty);
+    } else {
+        result = L2Sqr(vec1.data(), vec2.data(), &qty);
+    }
+
+    float diff = std::fabs(result - expected);
+    if (diff > 1e-4f) {
+        std::cout << "[FAIL] L2 test for N=" << N 
+                  << " | Result: " << result 
+                  << " | Expected: " << expected 
+                  << " | Diff: " << diff << std::endl;
+        return false;
+    } else {
+        std::cout << "[PASS] L2 test for N=" << N << std::endl;
+        return true;
+    }
+}
+
+int main() {
+    std::srand(static_cast<unsigned int>(std::time(nullptr)));
+
+    std::vector<size_t> test_sizes = {1024, 512, 65, 64, 37, 36, 18, 9, 3, 2, 1};
+    bool all_tests_passed = true;
+
+    std::cout << "=== Start testing the InnerProduct distance calculation. ===" << std::endl;
+    for (size_t size : test_sizes) {
+        if (!run_distance_ip_test(size)) {
+            all_tests_passed = false;
+        }
+    }
+
+    std::cout << "\n=== Start testing the L2 distance calculation. ===" << std::endl;
+    for (size_t size : test_sizes) {
+        if (!run_distance_l2_test(size)) {
+            all_tests_passed = false;
+        }
+    }
+
+    std::cout << "\n=== Result Summary ===" << std::endl;
+    if (all_tests_passed) {
+        std::cout << "All tests passed!" << std::endl;
+        return 0;
+    } else {
+        std::cout << "Some tests failed!" << std::endl;
+        return 1;
+    }
+}

--- a/tests/cpp/distance_calculation_neon.cpp
+++ b/tests/cpp/distance_calculation_neon.cpp
@@ -1,7 +1,3 @@
-/*
- * Copyright 2026 Huawei Technologies Co., Ltd.
- */
-
 #include <cstring>
 #include <vector>
 #include <cmath>


### PR DESCRIPTION
### Summary

- This PR introduces ARM NEON optimizations for IP and L2 distance calculations.

### Changes

- An ARM NEON-based implementation has been added for IP and L2 distance calculations.

### Design Decisions

- The macro is protected, and the macro naming follows the native naming convention, thus having no impact on X86 builds.

### Testing

- Unit tests for the NEON implementation of distance calculations have been added.

- Benchmark results show a significant performance improvement on ARM servers.

### Notes

- We are happy to work with the maintainers to refine the code structure as needed.

- If this contribution is well received, we have additional optimizations to offer, such as a NEON implementation for FP16 distance calculations and an optimization for ID reordering in the HNSW base library, which can be submitted in subsequent PRs.