### PR TITLE
fix(python): parallelize small high-dimensional query/add batches

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -260,8 +260,10 @@ class Index {
         if (features != dim)
             throw std::runtime_error("Wrong dimensionality of the vectors");
 
-        // avoid using threads when the number of additions is small:
-        if (rows <= num_threads * 4) {
+        // Avoid using threads when the total scalar work is too small to
+        // amortize thread-launch overhead. Use rows * dim as a proxy for work,
+        // so high-dimensional vectors are still parallelized in small batches.
+        if (rows * features <= static_cast<size_t>(num_threads) * 64) {
             num_threads = 1;
         }
 
@@ -627,8 +629,11 @@ class Index {
             py::gil_scoped_release l;
             get_input_array_shapes(buffer, &rows, &features);
 
-            // avoid using threads when the number of searches is small:
-            if (rows <= num_threads * 4) {
+            // Avoid using threads when the total scalar work is too small to
+            // amortize thread-launch overhead. Use rows * dim as a proxy for
+            // work, so high-dimensional queries are still parallelized in small
+            // batches.
+            if (rows * features <= static_cast<size_t>(num_threads) * 64) {
                 num_threads = 1;
             }
 

--- a/tests/python/bindings_test_small_batch_threading.py
+++ b/tests/python/bindings_test_small_batch_threading.py
@@ -1,0 +1,75 @@
+import multiprocessing
+import statistics
+import time
+import unittest
+
+import numpy as np
+
+import hnswlib
+
+
+class SmallBatchHighDimThreadingTestCase(unittest.TestCase):
+    """Regression test for https://github.com/nmslib/hnswlib/issues/667.
+
+    With the old rows-only threshold, knn_query forced single-threaded
+    execution for small batches. For high-dimensional vectors this hurts
+    performance because each vector still does enough work to benefit from
+    parallelization.
+    """
+
+    def setUp(self):
+        self.num_elements = 20000
+        self.dim = 1024
+        self.batch_size = 8
+        self.k = 10
+        np.random.seed(42)
+        self.data = np.float32(np.random.random((self.num_elements, self.dim)))
+        self.queries = np.float32(np.random.random((self.batch_size, self.dim)))
+
+        self.index = hnswlib.Index(space='l2', dim=self.dim)
+        self.index.init_index(max_elements=self.num_elements, ef_construction=200, M=16)
+        # Build the index with all available cores; this path is unaffected by
+        # the query-time threading heuristic.
+        self.index.add_items(self.data, num_threads=-1)
+        self.index.set_ef(200)
+
+    def _median_query_time(self, num_threads, repeats=10, loops=10):
+        self.index.set_num_threads(num_threads)
+        # Warmup to ensure any lazy state is created before timing.
+        self.index.knn_query(self.queries, k=self.k)
+
+        times = []
+        for _ in range(repeats):
+            start = time.perf_counter()
+            for _ in range(loops):
+                self.index.knn_query(self.queries, k=self.k)
+            times.append(time.perf_counter() - start)
+        return statistics.median(times)
+
+    def test_small_batch_high_dim_query_uses_multiple_threads(self):
+        # Skip on single-core machines where parallelization cannot help.
+        if multiprocessing.cpu_count() < 2:
+            self.skipTest('Need at least 2 CPUs to measure parallel speedup')
+
+        t_single = self._median_query_time(num_threads=1)
+        t_multi = self._median_query_time(num_threads=4)
+
+        # Correctness must be identical regardless of thread count.
+        self.index.set_num_threads(1)
+        labels_single, distances_single = self.index.knn_query(self.queries, k=self.k)
+        self.index.set_num_threads(4)
+        labels_multi, distances_multi = self.index.knn_query(self.queries, k=self.k)
+
+        np.testing.assert_array_equal(labels_single, labels_multi)
+        np.testing.assert_allclose(distances_single, distances_multi, rtol=1e-5)
+
+        # The bug manifested as t_multi ~= t_single because the small batch
+        # forced serial execution. After the fix, multiple threads should be
+        # measurably faster. Guard against noise with a conservative threshold.
+        speedup = t_single / t_multi
+        self.assertGreater(
+            speedup, 1.3,
+            f"Expected parallel query to be faster for high-dim small batch, "
+            f"got speedup {speedup:.2f}x (single={t_single:.4f}s, "
+            f"multi={t_multi:.4f}s)"
+        )


### PR DESCRIPTION
Closes #667.

The current Python bindings disabled multithreading whenever the input batch was smaller than 4 * num_threads, regardless of vector dimension. For high-dimensional vectors the per-query work is large enough that serial execution wastes cores.

This change replaces the rows-only threshold with a total-scalar-work threshold (rows * dim). It keeps the existing serialization behavior for low-dimensional vectors while letting small high-dimensional batches use multiple threads.

Changes:
- Use rows * dim to decide whether to fall back to a single thread in both addItems and knn_query.
- Add bindings_test_small_batch_threading.py, a regression test that verifies parallel knn_query is measurably faster than serial for a small, high-dimensional batch.

Tested: python -m unittest discover --start-directory tests/python --pattern "bindings_test*.py" => 15 tests passed.