### PR TITLE
Make saveIndex and saveIndexNoExceptions const

### DIFF
--- a/hnswlib/bruteforce.h
+++ b/hnswlib/bruteforce.h
@@ -131,7 +131,7 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
     }
 
 
-    Status saveIndexNoExceptions(std::ostream &output) {
+    Status saveIndexNoExceptions(std::ostream &output) const {
         writeBinaryPOD(output, maxelements_);
         writeBinaryPOD(output, size_per_element_);
         writeBinaryPOD(output, cur_element_count);
@@ -141,7 +141,7 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
     }
 
 
-    Status saveIndexNoExceptions(const std::string &location) override {
+    Status saveIndexNoExceptions(const std::string &location) const override {
         std::ofstream output(location, std::ios::binary);
 
         Status status = saveIndexNoExceptions(output);

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -724,7 +724,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         return size;
     }
 
-    Status saveIndexNoExceptions(std::ostream &output) {
+    Status saveIndexNoExceptions(std::ostream &output) const {
         writeBinaryPOD(output, offsetLevel0_);
         writeBinaryPOD(output, max_elements_);
         writeBinaryPOD(output, cur_element_count);
@@ -752,7 +752,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     }
 
 
-    Status saveIndexNoExceptions(const std::string &location) override {
+    Status saveIndexNoExceptions(const std::string &location) const override {
         std::ofstream output(location, std::ios::binary);
         Status status = saveIndexNoExceptions(output);
         if (!status.ok()) {

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -343,14 +343,14 @@ class AlgorithmInterface {
         return final_vector;
     }
 
-    virtual void saveIndex(const std::string &location) {
+    virtual void saveIndex(const std::string &location) const {
         Status status = saveIndexNoExceptions(location);
         if (!status.ok()) {
             HNSWLIB_THROW_RUNTIME_ERROR(status.message());
         }
     }
 
-    virtual Status saveIndexNoExceptions(const std::string &location) = 0;
+    virtual Status saveIndexNoExceptions(const std::string &location) const = 0;
 
     virtual ~AlgorithmInterface(){
     }

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -224,7 +224,7 @@ class Index {
         return appr_alg->indexFileSize();
     }
 
-    void saveIndex(const std::string &path_to_index) {
+    void saveIndex(const std::string &path_to_index) const {
         appr_alg->saveIndex(path_to_index);
     }
 
@@ -833,7 +833,7 @@ class BFIndex {
     }
 
 
-    void saveIndex(const std::string &path_to_index) {
+    void saveIndex(const std::string &path_to_index) const {
         alg->saveIndex(path_to_index);
     }
 


### PR DESCRIPTION
Closes #642.

Makes `saveIndex` and `saveIndexNoExceptions` `const` on `AlgorithmInterface`, `HierarchicalNSW`, `BruteforceSearch`, and the Python wrapper classes. Saving an index is read-only, so this lets users save a `const` index (or save in parallel with `const` searches) without a `const_cast`.