### PR TITLE
add_items: insert in a random permutation by default

### DIFF
--- a/ALGO_PARAMS.md
+++ b/ALGO_PARAMS.md
@@ -29,3 +29,5 @@ for M nearest neighbor search when ```ef``` =```ef_construction```: if the recal
 for improvement.
 * ```num_elements``` - defines the maximum number of elements in the index. The index can be extended by saving/loading (load_index
 function has a parameter which defines the new maximum number of elements).
+
+* ```shuffle``` - whether ```add_items``` inserts the rows of the batch in a random permutation (default) or in array order. On a collection that is stored in a meaningful order (e.g. sorted by document) inserting in that order may degrade the graph. Set ```shuffle=False``` if you need the insertion order preserved; labels are unaffected either way.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ For other spaces use the nmslib library https://github.com/nmslib/nmslib.
     * `M` defines tha maximum number of outgoing connections in the graph ([ALGO_PARAMS.md](ALGO_PARAMS.md)).
     * `allow_replace_deleted` enables replacing of deleted elements with new added ones.
     
-* `add_items(data, ids, num_threads = -1, replace_deleted = False)` - inserts the `data`(numpy array of vectors, shape:`N*dim`) into the structure. 
+* `add_items(data, ids, num_threads = -1, replace_deleted = False, shuffle = True)` - inserts the `data`(numpy array of vectors, shape:`N*dim`) into the structure. 
     * `num_threads` sets the number of cpu threads to use (-1 means use default).
     * `ids` are optional N-size numpy array of integer labels for all elements in `data`. 
       - If index already has the elements with the same labels, their features will be updated. Note that update procedure is slower than insertion of a new element, but more memory- and query-efficient.
     * `replace_deleted` replaces deleted elements. Note it allows to save memory.
       - to use it `init_index` should be called with `allow_replace_deleted=True`
+    * `shuffle` inserts the rows of `data` in a random permutation instead of the order they appear in the array (see [ALGO_PARAMS.md](ALGO_PARAMS.md)). Labels are unaffected: only the order of insertion changes. Set `shuffle=False` to insert in array order.
     * Thread-safe with other `add_items` calls, but not with `knn_query`.
     
 * `mark_deleted(label)`  - marks the element as deleted, so it will be omitted from search results. Throws an exception if it is already deleted.

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -6,6 +6,9 @@
 #include "hnswlib.h"
 #include <thread>
 #include <atomic>
+#include <algorithm>
+#include <numeric>
+#include <random>
 #include <stdlib.h>
 #include <assert.h>
 
@@ -151,6 +154,7 @@ class Index {
     int dim;
     size_t seed;
     size_t default_ef;
+    std::mt19937 shuffle_rng;
 
     bool index_inited;
     bool ep_added;
@@ -177,6 +181,7 @@ class Index {
         ep_added = true;
         index_inited = false;
         num_threads_default = std::thread::hardware_concurrency();
+        shuffle_rng.seed(100);
 
         default_ef = 10;
     }
@@ -204,6 +209,7 @@ class Index {
         ep_added = false;
         appr_alg->ef_ = default_ef;
         seed = random_seed;
+        shuffle_rng.seed(random_seed);
     }
 
 
@@ -248,7 +254,8 @@ class Index {
     }
 
 
-    void addItems(py::object input, py::object ids_ = py::none(), int num_threads = -1, bool replace_deleted = false) {
+    void addItems(py::object input, py::object ids_ = py::none(), int num_threads = -1, bool replace_deleted = false,
+                  bool shuffle = true) {
         py::array_t < dist_t, py::array::c_style | py::array::forcecast > items(input);
         auto buffer = items.request();
         if (num_threads <= 0)
@@ -282,15 +289,27 @@ class Index {
                 ep_added = true;
             }
 
+            // HNSW is analysed as an average case over a random insertion order. A corpus
+            // stored in a meaningful order (by document, by cluster, by label) violates
+            // that, and may cost accuracy, so insert in a random permutation by
+            // default. Labels are unaffected: only the order of the addPoint calls
+            // changes, not which label each vector is given.
+            std::vector<size_t> order(rows - start);
+            std::iota(order.begin(), order.end(), start);
+            if (shuffle)
+                std::shuffle(order.begin(), order.end(), shuffle_rng);
+
             py::gil_scoped_release l;
             if (normalize == false) {
-                ParallelFor(start, rows, num_threads, [&](size_t row, size_t threadId) {
+                ParallelFor(0, order.size(), num_threads, [&](size_t i, size_t threadId) {
+                    size_t row = order[i];
                     size_t id = ids.size() ? ids.at(row) : (cur_l + row);
                     appr_alg->addPoint((void*)items.data(row), (size_t)id, replace_deleted);
                     });
             } else {
                 std::vector<float> norm_array(num_threads * dim);
-                ParallelFor(start, rows, num_threads, [&](size_t row, size_t threadId) {
+                ParallelFor(0, order.size(), num_threads, [&](size_t i, size_t threadId) {
+                    size_t row = order[i];
                     // normalize vector:
                     size_t start_idx = threadId * dim;
                     normalize_vector((float*)items.data(row), (norm_array.data() + start_idx));
@@ -956,7 +975,8 @@ PYBIND11_PLUGIN(hnswlib) {
             py::arg("data"),
             py::arg("ids") = py::none(),
             py::arg("num_threads") = -1,
-            py::arg("replace_deleted") = false)
+            py::arg("replace_deleted") = false,
+            py::arg("shuffle") = true)
         .def("get_items", &Index<float>::getData, py::arg("ids") = py::none(), py::arg("return_type") = "numpy")
         .def("get_ids_list", &Index<float>::getIdsList)
         .def("set_ef", &Index<float>::set_ef, py::arg("ef"))

--- a/tests/python/bindings_test_shuffle.py
+++ b/tests/python/bindings_test_shuffle.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+
+import hnswlib
+
+
+def ordered_clustered_data(num_elements, dim, num_clusters, rng):
+    """Points emitted cluster by cluster, so the array is stored in a meaningful
+    order (the property a document-ordered corpus has and random data does not)."""
+    centers = rng.normal(0, 1.0, (num_clusters, dim)).astype(np.float32)
+    per_cluster = num_elements // num_clusters
+    return np.concatenate([
+        centers[c] + rng.normal(0, 0.35, (per_cluster, dim)).astype(np.float32)
+        for c in range(num_clusters)
+    ]).astype(np.float32)
+
+
+def build_and_measure_recall(data, queries, ground_truth, shuffle):
+    num_elements, dim = data.shape
+    p = hnswlib.Index(space='l2', dim=dim)
+    p.init_index(max_elements=num_elements, ef_construction=100, M=16, random_seed=100)
+    p.add_items(data, np.arange(num_elements), shuffle=shuffle)
+    p.set_ef(10)
+    labels, _ = p.knn_query(queries, k=ground_truth.shape[1])
+    k = ground_truth.shape[1]
+    return np.mean([len(set(a) & set(b)) / k for a, b in zip(labels, ground_truth)])
+
+
+class ShuffleTestCase(unittest.TestCase):
+    def testLabelsAreUnaffectedByShuffling(self):
+        """Shuffling reorders the addPoint calls only; the label a vector is
+        stored under must not change."""
+        dim = 16
+        num_elements = 2000
+        rng = np.random.default_rng(0)
+        data = ordered_clustered_data(num_elements, dim, 20, rng)
+        labels = np.arange(num_elements) * 7 + 3
+
+        p = hnswlib.Index(space='l2', dim=dim)
+        p.init_index(max_elements=num_elements, ef_construction=100, M=16)
+        p.add_items(data, labels)
+
+        self.assertEqual(sorted(p.get_ids_list()), sorted(labels.tolist()))
+        np.testing.assert_allclose(np.float32(p.get_items(labels)), data, rtol=1e-6)
+
+    def testShuffleImprovesRecallOnOrderedData(self):
+        """HNSW is analysed as an average case over a random insertion order.
+        On a corpus stored in a meaningful order, inserting in that order may cost
+        accuracy; shuffling recovers it."""
+        dim = 16
+        num_elements = 20000
+        rng = np.random.default_rng(0)
+        data = ordered_clustered_data(num_elements, dim, 100, rng)
+        queries = data[rng.choice(num_elements, 500, replace=False)]
+        ground_truth = np.argsort(
+            ((queries[:, None, :] - data[None, :, :]) ** 2).sum(-1), axis=1)[:, :10]
+
+        recall_in_order = build_and_measure_recall(data, queries, ground_truth, shuffle=False)
+        recall_shuffled = build_and_measure_recall(data, queries, ground_truth, shuffle=True)
+
+        print(f"\nordered corpus, recall@10: insertion order {recall_in_order:.4f}, "
+              f"shuffled {recall_shuffled:.4f}")
+        # The measured gap on this configuration is 0.018-0.025 over repeated
+        # builds; assert a fraction of it so the test does not depend on the
+        # non-determinism of a multi-threaded build.
+        self.assertGreater(recall_shuffled - recall_in_order, 0.005)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`HierarchicalNSW` randomises each element's **level** (`getRandomLevel`) but inserts elements in whatever order the caller supplies. HNSW's analysis is average-case over a **random insertion order** and the average case may not hold for a specific provided order, especially when the provided order is not random but given by some similarity factor (e.g. clustered documents from real world collections).

On a tested 8.8M-passage text embedding collection it is worth **~2 accuracy points at fixed `ef`**, and the graph needs **1.4×–2.6× the distance computations for equal recall**.

This PR makes `add_items` insert in a random permutation by default, with `shuffle=False` to opt out.

## Why the order matters

At the moment an element is inserted, its neighbours are selected from the elements already in the graph. It can acquire a later element only if that element subsequently selects it, and `getNeighborsByHeuristic2` is not symmetric, so often it does not. What the insertion order governs is therefore **what each element is allowed to choose from**, and the two orders differ in the *shape* of that candidate pool, not its size:

- **Random order:** the already-inserted prefix is a uniform sample of the collection. It covers the whole space at reduced density, so the candidate set the heuristic prunes is representative and the surviving neighbourhood approximates what the finished collection would give.
- **Caller's order on a sorted collection:** the prefix is a contiguous block. It covers *part* of the space rather than all of it, so through most of the build an element's neighbours are the best available within one region rather than the best overall.

The heuristic diversifies whatever pool it is handed; it cannot supply directions the pool does not contain. This is why the effect does not wash out as the graph grows.


## Evidence

Two arms differing **only** in insertion order, same unmodified library at `d9b3608`, same `getRandomLevel`, same `addPoint`, same `ParallelFor`. `M=32`, `ef_construction=200`, 64 build threads, `k=10`, accuracy@10 against exact ground truth. Machine: Intel Xeon Silver 4314 (2×16 cores, AVX-512, 503 GB RAM), `g++ -O3 -march=native -std=c++17`.

### 1. Synthetic, reproducible in ~2 minutes with no download

1M × 128 points drawn from 2,000 Gaussian clusters and written **cluster by cluster**, which manufactures the one property the effect needs — a file stored in a meaningful order. L2, 1,000 queries. **Three independent builds per arm**, mean ± sd:

| ef_search | file order | shuffled | delta |
|---:|---:|---:|---:|
| 15  | 81.49 ± 0.78 | 89.48 ± 0.83 | **+7.99** |
| 24  | 87.90 ± 1.23 | 95.82 ± 0.37 | **+7.91** |
| 32  | 90.55 ± 1.10 | 98.14 ± 0.18 | +7.59 |
| 45  | 92.79 ± 0.93 | 99.45 ± 0.07 | +6.66 |
| 90  | 95.47 ± 0.45 | 99.94 ± 0.07 | +4.46 |
| 150 | 96.77 ± 0.53 | 100.00 ± 0.00 | +3.23 |
| 200 | 97.47 ± 0.27 | 100.00 ± 0.00 | +2.53 |

Mean **+6.03** points over a 13-point `ef` ladder. The file-order arm never exceeds **97.6%** accuracy@10 at any beam width tested, while the shuffled arm saturates at 100%. File order is also markedly less stable build-to-build (sd up to 1.4, against ≤0.8 shuffled).

The generator is at the bottom of this description, numpy only, no download.

### 2. A real collection

MS MARCO v1 passage / Dragon embeddings, 8,841,823 × 768, inner product, 6,980 queries. One build per arm, three search repetitions each (search is deterministic, so the repetitions bound timing noise, not build noise; the build-noise estimate comes from SIFT1M below).

| ef_search | file order | shuffled | delta |
|---:|---:|---:|---:|
| 25  | 88.785 | 92.490 | **+3.71** |
| 45  | 92.845 | 95.493 | +2.65 |
| 90  | 95.517 | 97.279 | +1.76 |
| 160 | 96.951 | 98.337 | +1.39 |
| 300 | 97.855 | 98.894 | +1.04 |
| 520 | 98.414 | 99.242 | +0.83 |

Mean over the full 13-point ladder: **+1.98 accuracy points**.

Work-normalised, which is the stronger statement, distance computations needed to reach the same accuracy, both arms measured on the same two indexes:

| accuracy@10 target | shuffled, dist/query | file order, dist/query | ratio |
|---:|---:|---:|---:|
| 92.49 | 1020.7 | 1387.4 | **1.36×** |
| 95.49 | 1474.9 | 2408.9 | 1.63× |
| 97.28 | 2457.6 | 4806.2 | 1.96× |
| 98.34 | 3953.5 | 10426.4 | **2.64×** |

(file-order column interpolated across its own measured ladder.) Counting distance computations requires a small fix to `metric_distance_computations`, which does not fire at ground level as shipped; that is a separate issue and I will open it separately.

### 3. Control: the effect tracks corpus orderedness, as predicted

The effect requires the input file to be ordered. Measured directly on 4,000-row samples, we measure how similar (cosine for Dragon, L2 distance for SIFT1M) are consecutive vectors and random ones:

| collection | consecutive rows | random pairs | |
|---|---|---|---|
| Dragon (cosine similarity) | 0.478 | 0.180 | **2.7× more similar** |
| SIFT1M (L2 distance) | 479.4 | 525.8 | 0.91 — no ordering structure |

And the effect follows it: on SIFT1M, where the file is unordered, shuffling is worth only **+0.11** accuracy points on average (three independent builds per arm, per-point sd 0.03–0.12), against **+1.98** on Dragon.

## What this PR changes

- `add_items` gains `shuffle=True`. It permutes the batch and inserts in that order.
- **Labels are unaffected**: only the order of the `addPoint` calls changes, not which label a vector is stored under. Covered by a test.
- The permutation is drawn from a generator seeded with `init_index`'s `random_seed`, so builds stay reproducible to the extent they already were.
- Docs: one line in the `add_items` API description, one entry in `ALGO_PARAMS.md`.
- New test `tests/python/bindings_test_shuffle.py`: label integrity under shuffling, and the recall effect on a small ordered corpus (0.960 → 0.990 at the tested configuration, runs in ~1 s).

All existing Python test modules pass: `bindings_test`, `_labels`, `_getdata`, `_metadata`, `_pickle`, `_filter`, `_recall`, `_replace`, `_resize`, `_spaces`.

## Trade-offs, stated up front

- **Shuffling costs build time**, because file order gives the insertion searches artificial locality: Dragon 1498 s → 1726 s, SIFT1M 25.6 s → 28.0 s, synthetic 9.85 s → 14.03 s. So the current default is faster *and* worse. If a ~15% build-time regression on ordered data is unacceptable as a default, flipping the default to `shuffle=False` is a one-line change and users still get the switch.
- **`add_items` can only permute within the batch it is given**, so a user inserting in chunks of 1,000 gets little benefit. A single large call randomises thoroughly; this is a partial fix by construction.
- **Index contents change** for users who rebuild with this version. Results stay correct and labels are unchanged, but an index built now will not be identical to one built before.
- **The C++ API is unaffected**, because it has no batch insert. `addPoint` sees one point at a time and the caller has already fixed the order. C++ users have to permute at their own call site.

## Reproducing the synthetic result

```
python3 make_ordered_synthetic.py .
```

then build twice with `M=32`, `ef_construction=200`, once in array order, once with the rows permuted, and compare accuracy@10 across an `ef` ladder.

<details>
<summary>make_ordered_synthetic.py</summary>

```python
#!/usr/bin/env python3
"""Build a clustered, cluster-ordered synthetic collection that reproduces the
hnswlib insertion-order effect with no proprietary data.

The only property that matters is that the file is stored in a semantically
meaningful order, which is what a document-ordered text corpus gives you. Here
that is manufactured by generating points cluster by cluster and writing them out
in cluster order.
"""
import numpy as np, sys, os

out = sys.argv[1] if len(sys.argv) > 1 else "."
N, d, C, NQ, K = 1_000_000, 128, 2_000, 1_000, 10
rng = np.random.default_rng(42)

centers = rng.normal(0, 1.0, size=(C, d)).astype(np.float32)
per = N // C
# Points are emitted cluster by cluster, so the file is ORDERED.
data = np.empty((N, d), dtype=np.float32)
for c in range(C):
    data[c*per:(c+1)*per] = centers[c] + rng.normal(0, 0.35, size=(per, d)).astype(np.float32)

qc = rng.integers(0, C, size=NQ)
queries = (centers[qc] + rng.normal(0, 0.35, size=(NQ, d))).astype(np.float32)

# Exact top-K by L2, in chunks.
dn = (data * data).sum(1)
best_d = np.full((NQ, K), np.inf, np.float32); best_i = np.zeros((NQ, K), np.uint32)
CH = 50_000
for s in range(0, N, CH):
    e = min(s + CH, N)
    dist = dn[s:e][None, :] - 2.0 * (queries @ data[s:e].T)
    idx = np.argpartition(dist, K, axis=1)[:, :K]
    cand_d = np.take_along_axis(dist, idx, 1); cand_i = (idx + s).astype(np.uint32)
    alld = np.concatenate([best_d, cand_d], 1); alli = np.concatenate([best_i, cand_i], 1)
    keep = np.argpartition(alld, K, axis=1)[:, :K]
    best_d = np.take_along_axis(alld, keep, 1); best_i = np.take_along_axis(alli, keep, 1)
order = np.argsort(best_d, axis=1)
gt = np.take_along_axis(best_i, order, 1).astype(np.uint32)

np.save(os.path.join(out, "dataset.npy"), data)
np.save(os.path.join(out, "queries.npy"), queries)
np.save(os.path.join(out, "groundtruth.npy"), gt)

# Report the ordering structure, the property the effect depends on.
a = data[:4000].astype(np.float64)
cons = np.linalg.norm(a[:-1] - a[1:], axis=1).mean()
r = np.sort(rng.choice(N, 4000, replace=False)); b = data[r].astype(np.float64)
rnd = np.linalg.norm(b[:-1:2] - b[1::2], axis=1).mean()
print(f"N={N} d={d} clusters={C} queries={NQ} k={K}")
print(f"mean L2, consecutive rows {cons:.2f} | random pairs {rnd:.2f} | ratio {cons/rnd:.3f}")
print("(ratio well below 1.0 = the file is ordered, which is what the effect needs)")
```
</details>

Both real collections used above are public: [Dragon](https://huggingface.co/datasets/tuskanny/kannolo-msmarco-dragon) (27 GB) and [SIFT1M](https://huggingface.co/datasets/tuskanny/kannolo-sift1M) (0.5 GB).
