### PR TITLE
Return external labels from stop-condition search

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -1470,7 +1470,9 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         size_t sz = top_candidates.size();
         result.resize(sz);
         while (!top_candidates.empty()) {
-            result[--sz] = top_candidates.top();
+            const std::pair<dist_t, tableint> top_candidate = top_candidates.top();
+            result[--sz] = std::pair<dist_t, labeltype>(
+                top_candidate.first, getExternalLabel(top_candidate.second));
             top_candidates.pop();
         }
 

--- a/tests/cpp/epsilon_search_test.cpp
+++ b/tests/cpp/epsilon_search_test.cpp
@@ -4,7 +4,29 @@
 typedef unsigned int docidtype;
 typedef float dist_t;
 
+void TestSearchStopConditionReturnsExternalLabel() {
+    constexpr int kDim = 1;
+    constexpr size_t kMaxElements = 1;
+    constexpr hnswlib::labeltype kExternalLabel = 42;
+
+    float point[kDim] = {0.0f};
+
+    hnswlib::L2Space space(kDim);
+    hnswlib::HierarchicalNSW<dist_t> index(&space, kMaxElements);
+    index.addPoint(point, kExternalLabel);
+
+    hnswlib::EpsilonSearchStopCondition<dist_t> stop_condition(0.0f, 1, 1);
+    const std::vector<std::pair<dist_t, hnswlib::labeltype>> result =
+        index.searchStopConditionClosest(point, stop_condition);
+
+    assert(result.size() == 1);
+    assert(result.front().first == 0.0f);
+    assert(result.front().second == kExternalLabel);
+}
+
 int main() {
+    TestSearchStopConditionReturnsExternalLabel();
+
     int dim = 16;               // Dimension of the elements
     int max_elements = 10000;   // Maximum number of elements, should be known beforehand
     int M = 16;                 // Tightly connected with internal dimensionality of the data


### PR DESCRIPTION
## Summary

- Convert internal candidate IDs to their external labels before returning stop-condition search results.
- Preserve the existing distance order and pass external labels to `filter_results()` as its public contract requires.
- Add a deterministic regression using internal ID `0` and external label `42`.

Fixes #591.

## Validation

- Before the fix, the new regression failed on the external-label assertion with exit code 6.
- Default `epsilon_search_test`: 1/1 passed.
- `HNSWLIB_ENABLE_EXCEPTIONS=OFF` `epsilon_search_test`: 1/1 passed.
- Full default CTest suite: 15/15 passed.
- `git diff --check` passed.

The Python binding suite was not run because its `numpy` and `pybind11` dependencies were not available in the local environment; no dependency-download workaround was attempted.