### PR TITLE
Reuse visited lists across batched Python queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ set(HNSWLIB_TARGETS_REQUIRING_EXCEPTIONS
     example_mt_replace_deleted
     example_mt_search
     multiThread_replace_test
-    test_updates)
+    test_updates
+    visited_list_pool_test)
 
 set(EXAMPLE_NAMES
     example_epsilon_search
@@ -35,6 +36,7 @@ set(TEST_NAMES
     resize_test
     searchKnnCloserFirst_test
     searchKnnWithFilter_test
+    visited_list_pool_test
     )
 
 function(add_cxx_flags)

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -337,13 +337,13 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     // bare_bone_search means there is no check for deletions and stop condition is ignored in return of extra performance
     template <bool bare_bone_search = true, bool collect_metrics = false>
     std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
-    searchBaseLayerST(
+    searchBaseLayerSTWithVisitedList(
         tableint ep_id,
         const void *data_point,
         size_t ef,
+        VisitedList *vl,
         BaseFilterFunctor* isIdAllowed = nullptr,
         BaseSearchStopCondition<dist_t>* stop_condition = nullptr) const {
-        VisitedList *vl = visited_list_pool_->getFreeVisitedList();
         vl_type *visited_array = vl->mass;
         vl_type visited_array_tag = vl->curV;
 
@@ -470,6 +470,21 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
             }
         }
 
+        return top_candidates;
+    }
+
+
+    template <bool bare_bone_search = true, bool collect_metrics = false>
+    std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst>
+    searchBaseLayerST(
+        tableint ep_id,
+        const void *data_point,
+        size_t ef,
+        BaseFilterFunctor* isIdAllowed = nullptr,
+        BaseSearchStopCondition<dist_t>* stop_condition = nullptr) const {
+        VisitedList *vl = visited_list_pool_->getFreeVisitedList();
+        auto top_candidates = searchBaseLayerSTWithVisitedList<bare_bone_search, collect_metrics>(
+            ep_id, data_point, ef, vl, isIdAllowed, stop_condition);
         visited_list_pool_->releaseVisitedList(vl);
         return top_candidates;
     }
@@ -1353,11 +1368,12 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
     using DistanceLabelPriorityQueue = typename AlgorithmInterface<dist_t>::DistanceLabelPriorityQueue;
 
-    virtual StatusOr<DistanceLabelPriorityQueue>
-    searchKnnNoExceptions(
+ private:
+    StatusOr<DistanceLabelPriorityQueue> searchKnnInternalNoExceptions(
             const void *query_data,
             size_t k,
-            BaseFilterFunctor* isIdAllowed = nullptr) const override {
+            BaseFilterFunctor* isIdAllowed,
+            VisitedList *visited_list) const {
         std::priority_queue<std::pair<dist_t, labeltype >> result;
         if (cur_element_count == 0) return result;
 
@@ -1394,11 +1410,21 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         std::priority_queue<std::pair<dist_t, tableint>, std::vector<std::pair<dist_t, tableint>>, CompareByFirst> top_candidates;
         bool bare_bone_search = !num_deleted_ && !isIdAllowed;
         if (bare_bone_search) {
-            top_candidates = searchBaseLayerST<true>(
-                    currObj, query_data, std::max(ef_, k), isIdAllowed);
+            if (visited_list) {
+                top_candidates = searchBaseLayerSTWithVisitedList<true>(
+                        currObj, query_data, std::max(ef_, k), visited_list, isIdAllowed);
+            } else {
+                top_candidates = searchBaseLayerST<true>(
+                        currObj, query_data, std::max(ef_, k), isIdAllowed);
+            }
         } else {
-            top_candidates = searchBaseLayerST<false>(
-                    currObj, query_data, std::max(ef_, k), isIdAllowed);
+            if (visited_list) {
+                top_candidates = searchBaseLayerSTWithVisitedList<false>(
+                        currObj, query_data, std::max(ef_, k), visited_list, isIdAllowed);
+            } else {
+                top_candidates = searchBaseLayerST<false>(
+                        currObj, query_data, std::max(ef_, k), isIdAllowed);
+            }
         }
 
         while (top_candidates.size() > k) {
@@ -1410,6 +1436,40 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
             top_candidates.pop();
         }
         return result;
+    }
+
+ public:
+    virtual StatusOr<DistanceLabelPriorityQueue>
+    searchKnnNoExceptions(
+            const void *query_data,
+            size_t k,
+            BaseFilterFunctor* isIdAllowed = nullptr) const override {
+        return searchKnnInternalNoExceptions(query_data, k, isIdAllowed, nullptr);
+    }
+
+
+    DistanceLabelPriorityQueue searchKnnWithVisitedList(
+            const void *query_data,
+            size_t k,
+            VisitedList *visited_list,
+            BaseFilterFunctor* isIdAllowed = nullptr) const {
+        auto result = searchKnnWithVisitedListNoExceptions(query_data, k, visited_list, isIdAllowed);
+        if (!result.ok()) {
+            HNSWLIB_THROW_RUNTIME_ERROR(result.status().message());
+        }
+        return std::move(result.value());
+    }
+
+
+    StatusOr<DistanceLabelPriorityQueue> searchKnnWithVisitedListNoExceptions(
+            const void *query_data,
+            size_t k,
+            VisitedList *visited_list,
+            BaseFilterFunctor* isIdAllowed = nullptr) const {
+        if (visited_list == nullptr) {
+            return Status("searchKnnWithVisitedList requires an initialized VisitedList");
+        }
+        return searchKnnInternalNoExceptions(query_data, k, isIdAllowed, visited_list);
     }
 
     using DistanceLabelVector = typename AlgorithmInterface<dist_t>::DistanceLabelVector;

--- a/hnswlib/visited_list_pool.h
+++ b/hnswlib/visited_list_pool.h
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <string.h>
 #include <deque>
+#include <memory>
 
 namespace hnswlib {
 typedef unsigned short int vl_type;
@@ -28,6 +29,35 @@ class VisitedList {
     }
 
     ~VisitedList() { delete[] mass; }
+};
+
+class VisitedListPool;
+
+// Owns one VisitedList for the duration of a batch worker. Acquisition
+// prepares the first search generation; next() prepares each later search.
+class VisitedListLease {
+    VisitedListPool *pool_;
+    VisitedList *visited_list_;
+
+    VisitedListLease(VisitedListPool *pool, VisitedList *visited_list)
+        : pool_(pool), visited_list_(visited_list) {}
+
+    friend class VisitedListPool;
+
+ public:
+    VisitedListLease(const VisitedListLease &) = delete;
+    VisitedListLease &operator=(const VisitedListLease &) = delete;
+
+    VisitedList *get() const {
+        return visited_list_;
+    }
+
+    VisitedList *next() {
+        visited_list_->reset();
+        return visited_list_;
+    }
+
+    ~VisitedListLease();
 };
 ///////////////////////////////////////////////////////////
 //
@@ -67,6 +97,10 @@ class VisitedListPool {
         pool.push_front(vl);
     }
 
+    std::unique_ptr<VisitedListLease> getFreeVisitedListLease() {
+        return std::unique_ptr<VisitedListLease>(new VisitedListLease(this, getFreeVisitedList()));
+    }
+
     ~VisitedListPool() {
         while (pool.size()) {
             VisitedList *rez = pool.front();
@@ -75,4 +109,8 @@ class VisitedListPool {
         }
     }
 };
+
+inline VisitedListLease::~VisitedListLease() {
+    pool_->releaseVisitedList(visited_list_);
+}
 }  // namespace hnswlib

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -640,11 +640,21 @@ class Index {
             // Warning: search with a filter works slow in python in multithreaded mode. For best performance set num_threads=1
             CustomFilterFunctor idFilter(filter);
             CustomFilterFunctor* p_idFilter = filter ? &idFilter : nullptr;
+            size_t visited_list_count = num_threads <= 0 ? std::thread::hardware_concurrency() : num_threads;
+            std::vector<std::unique_ptr<hnswlib::VisitedListLease>> visited_list_leases(visited_list_count);
 
             if (normalize == false) {
                 ParallelFor(0, rows, num_threads, [&](size_t row, size_t threadId) {
-                    std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result = appr_alg->searchKnn(
-                        (void*)items.data(row), k, p_idFilter);
+                    hnswlib::VisitedList *visited_list;
+                    if (!visited_list_leases[threadId]) {
+                        visited_list_leases[threadId] = appr_alg->visited_list_pool_->getFreeVisitedListLease();
+                        visited_list = visited_list_leases[threadId]->get();
+                    } else {
+                        visited_list = visited_list_leases[threadId]->next();
+                    }
+                    std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result =
+                        appr_alg->searchKnnWithVisitedList(
+                            (void*)items.data(row), k, visited_list, p_idFilter);
                     if (result.size() != k)
                         HNSWLIB_THROW_RUNTIME_ERROR(
                             "Cannot return the results in a contiguous 2D array. Probably ef or M is too small");
@@ -663,8 +673,16 @@ class Index {
                     size_t start_idx = threadId * dim;
                     normalize_vector((float*)items.data(row), (norm_array.data() + start_idx));
 
-                    std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result = appr_alg->searchKnn(
-                        (void*)(norm_array.data() + start_idx), k, p_idFilter);
+                    hnswlib::VisitedList *visited_list;
+                    if (!visited_list_leases[threadId]) {
+                        visited_list_leases[threadId] = appr_alg->visited_list_pool_->getFreeVisitedListLease();
+                        visited_list = visited_list_leases[threadId]->get();
+                    } else {
+                        visited_list = visited_list_leases[threadId]->next();
+                    }
+                    std::priority_queue<std::pair<dist_t, hnswlib::labeltype >> result =
+                        appr_alg->searchKnnWithVisitedList(
+                            (void*)(norm_array.data() + start_idx), k, visited_list, p_idFilter);
                     if (result.size() != k)
                         HNSWLIB_THROW_RUNTIME_ERROR(
                             "Cannot return the results in a contiguous 2D array. Probably ef or M is too small");

--- a/tests/cpp/visited_list_pool_test.cpp
+++ b/tests/cpp/visited_list_pool_test.cpp
@@ -1,0 +1,46 @@
+#include "../../hnswlib/visited_list_pool.h"
+
+#include <cassert>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+
+static_assert(!std::is_copy_constructible<hnswlib::VisitedListLease>::value,
+              "VisitedListLease must not be copy constructible");
+static_assert(!std::is_copy_assignable<hnswlib::VisitedListLease>::value,
+              "VisitedListLease must not be copy assignable");
+
+int main() {
+    hnswlib::VisitedListPool pool(1, 8);
+
+    hnswlib::VisitedList *leased_pointer = nullptr;
+    try {
+        auto lease = pool.getFreeVisitedListLease();
+        leased_pointer = lease->get();
+        assert(leased_pointer->curV == 1);
+
+        leased_pointer->mass[2] = leased_pointer->curV;
+        hnswlib::vl_type previous_generation = leased_pointer->curV;
+        assert(lease->next() == leased_pointer);
+        assert(leased_pointer->curV == previous_generation + 1);
+        assert(leased_pointer->mass[2] != leased_pointer->curV);
+
+        for (unsigned int i = 0; i < leased_pointer->numelements; ++i) {
+            leased_pointer->mass[i] = 123;
+        }
+        leased_pointer->curV = std::numeric_limits<hnswlib::vl_type>::max();
+        lease->next();
+        assert(leased_pointer->curV == 1);
+        for (unsigned int i = 0; i < leased_pointer->numelements; ++i) {
+            assert(leased_pointer->mass[i] == 0);
+        }
+
+        throw std::runtime_error("exercise exceptional lease return");
+    } catch (const std::runtime_error &) {
+    }
+
+    auto returned_lease = pool.getFreeVisitedListLease();
+    assert(returned_lease->get() == leased_pointer);
+    assert(returned_lease->get()->curV == 2);
+    return 0;
+}

--- a/tests/python/bindings_test_query_workspace.py
+++ b/tests/python/bindings_test_query_workspace.py
@@ -1,0 +1,73 @@
+import concurrent.futures
+import unittest
+
+import hnswlib
+import numpy as np
+
+
+class QueryWorkspaceTest(unittest.TestCase):
+    @staticmethod
+    def make_index(space):
+        rng = np.random.default_rng(9017)
+        data = rng.standard_normal((512, 16), dtype=np.float32)
+        queries = rng.standard_normal((65, 16), dtype=np.float32)
+        index = hnswlib.Index(space=space, dim=16)
+        index.init_index(max_elements=len(data), M=16, ef_construction=100, random_seed=77)
+        index.add_items(data, np.arange(len(data)), num_threads=4)
+        index.set_ef(48)
+        return index, queries
+
+    def assert_query_equal(self, expected, actual):
+        np.testing.assert_array_equal(expected[0], actual[0])
+        np.testing.assert_array_equal(expected[1], actual[1])
+
+    def test_spaces_and_64_65_scheduling_boundary(self):
+        for space in ("l2", "ip", "cosine"):
+            with self.subTest(space=space):
+                index, queries = self.make_index(space)
+                for rows in (64, 65):
+                    expected = index.knn_query(queries[:rows], k=10, num_threads=1)
+                    actual = index.knn_query(queries[:rows], k=10, num_threads=16)
+                    self.assert_query_equal(expected, actual)
+
+    def test_deletions_filter_exception_and_reuse(self):
+        index, queries = self.make_index("l2")
+        for label in range(0, 512, 19):
+            index.mark_deleted(label)
+
+        allowed = lambda label: label % 3 != 0
+        expected = index.knn_query(queries, k=10, num_threads=1, filter=allowed)
+        actual = index.knn_query(queries, k=10, num_threads=4, filter=allowed)
+        self.assert_query_equal(expected, actual)
+        index.set_num_threads(0)
+        self.assert_query_equal(expected, index.knn_query(queries, k=10, filter=allowed))
+        index.set_num_threads(4)
+
+        class RaisedFromFilter(RuntimeError):
+            pass
+
+        def raising_filter(label):
+            raise RaisedFromFilter("intentional callback failure")
+
+        with self.assertRaises(RaisedFromFilter):
+            index.knn_query(queries[:1], k=10, num_threads=1, filter=raising_filter)
+
+        self.assert_query_equal(expected, index.knn_query(queries, k=10, num_threads=4, filter=allowed))
+
+    def test_repeated_and_concurrent_batches(self):
+        index, queries = self.make_index("cosine")
+        expected = index.knn_query(queries, k=10, num_threads=1)
+        for _ in range(4):
+            self.assert_query_equal(expected, index.knn_query(queries, k=10, num_threads=4))
+
+        def run_query(_):
+            return index.knn_query(queries, k=10, num_threads=4)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(run_query, range(8)))
+        for result in results:
+            self.assert_query_equal(expected, result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR reduces visited-list pool locking in Python HNSW batch queries by leasing one `VisitedList` per active
`ParallelFor` worker instead of acquiring and returning one for every query row.

For a batch with `Q` rows and `W` active workers, the number of mutex-protected pool operations falls from roughly
`2Q` to at most `2 min(Q, W)`. Each row still receives a fresh visited generation, and the HNSW traversal and
distance calculations are unchanged.

## Implementation

The patch adds a non-copyable RAII `VisitedListLease`. Pool acquisition performs the first existing generation
reset, `next()` performs one reset before every subsequent row, and destruction returns the exact list to the
originating pool on both normal and exceptional exit.

The level-zero search implementation is factored so it can consume caller-owned visited scratch. The existing C++
`searchKnnNoExceptions` path retains its normal acquire/release behavior. Only Python `Index.knn_query` uses the new
entry point, with one lazily acquired lease per worker. Both normalized and non-normalized query paths use the same
lease protocol.

The patch does not change the graph, distance arithmetic, result ordering, index format, construction path,
`BFIndex`, or public Python signatures. The number of simultaneously live visited lists remains bounded by the
number of active workers.

## Performance

The A/B benchmark used 30,000 deterministic standard-normal float32 base vectors, 2,000 held-out queries,
dimension 64, `M=24`, `ef_construction=120`, `ef_search=48`, `k=10`, and 16 query workers. For each of three build
seeds, baseline and candidate loaded the same baseline-produced serialized index. Each treatment ran in a fresh
process with two warmups and 31 retained full-batch timings.

| Build seed | Baseline QPS | Patched QPS | Gain | Recall baseline/patched | Output parity |
|---:|---:|---:|---:|---:|---|
| 7101 | 246,982 | 259,797 | **+5.19%** | 0.7785 / 0.7785 | byte-identical |
| 7102 | 247,714 | 259,439 | **+4.73%** | 0.7810 / 0.7810 | byte-identical |
| 7103 | 247,995 | 259,526 | **+4.65%** | 0.7810 / 0.7810 | byte-identical |

The median paired gain is **+4.73%**. The mean paired ratio is `1.0486x`, with a two-sided 95% paired-t interval of
`[1.0414x, 1.0558x]` over the three build seeds. Peak RSS ratios were 0.9960, 0.9998, and 0.9966, so no memory
increase was observed.

A separate two-round matrix measured one- and two-row calls within 0.6% of baseline and found improvements from
eight rows upward in the tested configurations. The performance claim is limited to batched Python queries and the
tested environment; it is not a universal throughput claim.

## Correctness and tests

- Release C++ build and CTest: 16/16 passed.
- Exception-disabled C++ build and CTest: 16/16 passed.
- `test_updates` and `test_updates update`: passed in both builds.
- Official Python unittest discovery: 17/17 passed, including the three new query-workspace cases.
- Python `BFIndex` test: passed; all five Python examples passed.
- AddressSanitizer full C++ suite: 16/16 passed with leak detection enabled.
- ASan+UBSan: 15/16 passed; the remaining `BruteforceSearch` misaligned-load finding reproduces unchanged on the
  unmodified base. The new focused test passes under the combined sanitizers.

The added tests cover generation wrap, exception return, l2/ip/cosine, normalized queries, filters, deletions,
repeated use, concurrent batches, and the serial/threaded scheduling boundary.

## Compatibility

The implementation is C++11-compatible and preserves the current exception-enabled and no-exception APIs. Index
serialization is unchanged. This PR targets `develop` at
`df5814a61d6ac129fff6e5c27aa3ab99474aefac`.

## AI assistance

OpenAI Codex `gpt-5.6-sol` with `xhigh` reasoning produced and screened the initial candidate. OpenAI Codex `gpt-5.6-sol` with `max` reasoning was used to port, review, and validate the final change.

  I reviewed and understand every submitted change.