### PR TITLE
fix(hnswalg): reject loadIndex when max_elements_ < cur_element_count

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -732,6 +732,11 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         if (max_elements < cur_element_count)
             max_elements = max_elements_;
         max_elements_ = max_elements;
+
+        if (max_elements_ < cur_element_count) {
+            throw std::runtime_error("Index seems to be corrupted or unsupported");
+        }
+
         readBinaryPOD(input, size_data_per_element_);
         readBinaryPOD(input, label_offset_);
         readBinaryPOD(input, offsetData_);

--- a/tests/python/bindings_test_loadindex_corruption.py
+++ b/tests/python/bindings_test_loadindex_corruption.py
@@ -1,0 +1,54 @@
+import os
+import struct
+import tempfile
+import unittest
+
+import numpy as np
+
+import hnswlib
+
+
+class LoadIndexCorruptionTestCase(unittest.TestCase):
+    def test_malformed_max_elements_throws(self):
+        """A crafted index with max_elements_ < cur_element_count must not load."""
+        dim = 8
+        index = hnswlib.Index(space='l2', dim=dim)
+        index.init_index(max_elements=2, ef_construction=10, M=4)
+        index.add_items(np.float32([[1.0] * dim, [2.0] * dim]))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'index.bin')
+            index.save_index(path)
+
+            # The header starts with offsetLevel0_ (size_t) followed by max_elements_ (size_t).
+            # Leave cur_element_count at 2 but shrink max_elements_ to 1 so the allocation
+            # would be smaller than the subsequent read.
+            size_t_size = struct.calcsize('N')
+            with open(path, 'r+b') as f:
+                f.seek(size_t_size)
+                f.write(struct.pack('N', 1))
+
+            fresh = hnswlib.Index(space='l2', dim=dim)
+            with self.assertRaises(RuntimeError):
+                fresh.load_index(path)
+
+    def test_legitimate_index_loads(self):
+        """Sanity check: a normal saved index still loads and searches correctly."""
+        dim = 8
+        index = hnswlib.Index(space='l2', dim=dim)
+        index.init_index(max_elements=10, ef_construction=10, M=4)
+        data = np.float32(np.random.random((5, dim)))
+        index.add_items(data)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'index.bin')
+            index.save_index(path)
+
+            fresh = hnswlib.Index(space='l2', dim=dim)
+            fresh.load_index(path)
+            labels, _ = fresh.knn_query(data, k=1)
+            self.assertTrue(np.all(labels.reshape(-1) == np.arange(len(data))))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #673

`loadIndex` sized the level-0 allocation from the file's `max_elements_` field but then read `cur_element_count * size_data_per_element_` bytes. A crafted index with `max_elements_ < cur_element_count` therefore caused a heap-buffer-overflow write.

Add a bound check right after `max_elements_` is finalized so malformed indexes throw `Index seems to be corrupted or unsupported` instead of overflowing.

Added `tests/python/bindings_test_loadindex_corruption.py` with two tests: one that crafts a malformed 2-element index with `max_elements_=1` and asserts loading raises `RuntimeError`, and one that verifies a normal saved index still loads and self-searches correctly.

All Python binding tests pass (16/16).