### PR TITLE
Replace push_back loop with range construction in getDataByLabelNoExceptions

### DIFF
--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -906,13 +906,8 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
         char* data_ptrv = getDataByInternalId(internalId);
         size_t dim = *((size_t *) dist_func_param_);
-        std::vector<data_t> data;
         data_t* data_ptr = (data_t*) data_ptrv;
-        for (size_t i = 0; i < dim; i++) {
-            data.push_back(*data_ptr);
-            data_ptr += 1;
-        }
-        return data;
+        return std::vector<data_t>(data_ptr, data_ptr + dim);
     }
 
     void markDelete(labeltype label) {


### PR DESCRIPTION
Addresses the allocation half of #643.

`getDataByLabelNoExceptions` builds its return vector with an unreserved `push_back` loop, so a `dim`-element result triggers roughly log2(dim) reallocations, copying the accumulated data at each one. The size is known before the loop starts, so a range constructor does it in one allocation and one copy. For trivially copyable types the contiguous iterator pair also dispatches to a single `memmove` rather than `dim` individual push_backs.

No behavior change: same data, same locks, same error paths.

### Measurements

Single-threaded, so the effect isn't masked by lock contention. 10k elements, 200k calls per measurement, 9 trials, median reported:

| dim  | push_back | range ctor | delta     |
|------|-----------|------------|-----------|
| 32   | 240.8 ns  | 99.1 ns    | -141.7 ns |
| 128  | 536.6 ns  | 227.6 ns   | -309.1 ns |
| 512  | 1680.4 ns | 784.3 ns   | -896.1 ns |
| 1024 | 2986.7 ns | 1457.5 ns  | -1529.1 ns |

Trial ranges do not overlap at any dimension. The relative saving holds at 51-59% across a 32x range in `dim`.

Ubuntu 24.04 (WSL2), g++ 13.3, `-O3 -DNDEBUG -std=c++11`, Ryzen 7 3700X. These flags differ from CI's `RelWithDebInfo`; I used `-O3 -DNDEBUG` to avoid `-march=native` tying the numbers to this specific CPU.

Timing is batched at 256 calls so `steady_clock` overhead stays under 1% of each measured interval, with a warmup pass, trials interleaved across variants, and a correctness check that both versions return identical data before any timing is reported.

### Verification

Built and tested locally against the CI matrix: `RelWithDebInfo` with exceptions ON and OFF, plus ASan+UBSan. 15/15 ctest, `test_updates` in both modes, and the Python bindings suite all pass. No warnings under `-Wall -Wextra -Wpedantic -Werror`.

### Not included

#643 also proposes a raw-pointer accessor. I left that out: callers can already compose `getInternalIdByLabel` (#632) with `getDataByInternalId` to get the same thing without new API, and any new method would need a `NoExceptions` counterpart to match the convention from #619. Happy to follow up separately if that's wanted.